### PR TITLE
chore: dockerfile alpine fix go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as builder
+FROM golang:1.15.8-alpine as builder
 RUN apk add --update make git
 ADD . /webhook/
 WORKDIR /webhook/


### PR DESCRIPTION
Alpine version is using go version [1.16.](https://hub.docker.com/layers/golang/library/golang/alpine/images/sha256-353e19718d4aa37cb38cf362e5aba23e22b8680bfc18255408ccd9b7b777c469?context=explore)
Fixing the dockerfile with the 1.15 to avoid errors with the `make all` 

```
#17 8.602 building....
#17 8.602 go install  webhooksrv
#17 8.606 go install: version is required when current directory is not in a module
#17 8.606 	Try 'go install webhooksrv@latest' to install the latest version
```
Testing the publish gh-action in the branch [docker-test](https://github.com/aquasecurity/postee/runs/2008941641?check_suite_focus=true)