### PR TITLE
Fix db file relative path usage

### DIFF
--- a/dbservice/actions.go
+++ b/dbservice/actions.go
@@ -18,7 +18,7 @@ func HandleCurrentInfo(scanInfo *data.ScanImageInfo) (prev []byte, isNew bool, e
 		prevId = data.BuildUniqueId(scanInfo.PreviousDigest, scanInfo.Image, scanInfo.Registry)
 	}
 
-	db, err := bolt.Open(DbPath, 0666, nil)
+	db, err := bolt.Open(GetAbsDbPath(DbPath), 0666, nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/dbservice/checker.go
+++ b/dbservice/checker.go
@@ -14,9 +14,10 @@ func CheckSizeLimit() {
 	mutex.Lock()
 	defer mutex.Unlock()
 
-	db, err := bolt.Open(DbPath, 0666, nil)
+	dbPath := GetAbsDbPath(DbPath)
+	db, err := bolt.Open(dbPath, 0666, nil)
 	if err != nil {
-		log.Println("CheckSizeLimit: Can't open db:", DbPath)
+		log.Println("CheckSizeLimit: Can't open db:", dbPath)
 		return
 	}
 	defer db.Close()
@@ -48,9 +49,10 @@ func CheckExpiredData() {
 	mutex.Lock()
 	defer mutex.Unlock()
 
-	db, err := bolt.Open(DbPath, 0666, nil)
+	dbPath := GetAbsDbPath(DbPath)
+	db, err := bolt.Open(dbPath, 0666, nil)
 	if err != nil {
-		log.Println("CheckExpiredData: Can't open db:", DbPath)
+		log.Println("CheckExpiredData: Can't open db:", dbPath)
 		return
 	}
 	defer db.Close()

--- a/dbservice/dbaggregator.go
+++ b/dbservice/dbaggregator.go
@@ -12,7 +12,7 @@ func AggregateScans(plugin string,
 	mutex.Lock()
 	defer mutex.Unlock()
 
-	db, err := bolt.Open(DbPath, 0666, nil)
+	db, err := bolt.Open(GetAbsDbPath(DbPath), 0666, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dbservice/dbparam.go
+++ b/dbservice/dbparam.go
@@ -1,6 +1,8 @@
 package dbservice
 
 import (
+	"log"
+	"path/filepath"
 	"sync"
 	"time"
 )
@@ -22,4 +24,17 @@ func ChangeDbPath(newPath string) {
 	mutex.Lock()
 	DbPath = newPath
 	mutex.Unlock()
+}
+
+func GetAbsDbPath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		log.Println(err)
+		// on error, fall back to the supplied path
+		return path
+	}
+	return absPath
 }


### PR DESCRIPTION
`DbPath = "/server/database/webhooks.db"`

- DbPath points to a relative path, yet file open operations require the full path exists for the file creation. 
- `/server/database/` exists and is created as per the Dockerfile, yet an absolute file reference must be made for such operation to succeed.
- Switching to using an absolute path while failing over to the default/user supplied path.
