### PR TITLE
Default login credential are incorrect in docs

### DIFF
--- a/PosteeUI.md
+++ b/PosteeUI.md
@@ -26,5 +26,5 @@ Name | Description | Default value
 POSTEE_UI_CFG|Path to app config| required, no default value
 POSTEE_UI_PORT|Port to use with UI app| 8090
 POSTEE_UI_UPDATE_URL|Url of webhook application|required
-POSTEE_ADMIN_USER|Admin account name|admin
-POSTEE_ADMIN_PASSWORD|Admin account password|admin
+POSTEE_ADMIN_USER|Admin account name|demo
+POSTEE_ADMIN_PASSWORD|Admin account password|demo


### PR DESCRIPTION
Deploying using the readme (link below) creates postee  with the default creds as demo:demo not admin:admin as stated in the docs.
 Link: https://github.com/aquasecurity/postee/tree/main/deploy/kubernetes 
command: `kubectl create -f https://raw.githubusercontent.com/aquasecurity/postee/main/deploy/kubernetes/postee.yaml`