### PR TITLE
refactor: changed go module to v2

### DIFF
--- a/formatting/eval.go
+++ b/formatting/eval.go
@@ -8,8 +8,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/aquasecurity/postee/data"
-	"github.com/aquasecurity/postee/layout"
+	"github.com/aquasecurity/postee/v2/data"
+	"github.com/aquasecurity/postee/v2/layout"
 )
 
 type legacyScnEvaluator struct {

--- a/formatting/markup_test.go
+++ b/formatting/markup_test.go
@@ -1,8 +1,9 @@
 package formatting
 
 import (
-	"github.com/aquasecurity/postee/layout"
 	"testing"
+
+	"github.com/aquasecurity/postee/v2/layout"
 )
 
 type tagsTest struct {

--- a/formatting/slackmrkdwnprovider.go
+++ b/formatting/slackmrkdwnprovider.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/aquasecurity/postee/data"
 	"log"
+
+	"github.com/aquasecurity/postee/v2/data"
 )
 
 func getMrkdwnText(text string) string {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aquasecurity/postee
+module github.com/aquasecurity/postee/v2
 
 go 1.15
 

--- a/layout/assurances.go
+++ b/layout/assurances.go
@@ -1,8 +1,9 @@
 package layout
 
 import (
-	"github.com/aquasecurity/postee/data"
 	"strconv"
+
+	"github.com/aquasecurity/postee/v2/data"
 )
 
 func RenderAssurances(provider LayoutProvider, assuranceResults data.ImageAssuranceResults) string {

--- a/layout/malware.go
+++ b/layout/malware.go
@@ -2,8 +2,9 @@ package layout
 
 import (
 	"bytes"
-	"github.com/aquasecurity/postee/data"
 	"strconv"
+
+	"github.com/aquasecurity/postee/v2/data"
 )
 
 func RenderMalware(malware []data.MalwareData, provider LayoutProvider, builder *bytes.Buffer) {

--- a/layout/sensitive.go
+++ b/layout/sensitive.go
@@ -2,7 +2,8 @@ package layout
 
 import (
 	"bytes"
-	"github.com/aquasecurity/postee/data"
+
+	"github.com/aquasecurity/postee/v2/data"
 )
 
 func RenderSensitiveData(sensitive []data.SensitiveData, provider LayoutProvider, builder *bytes.Buffer) {

--- a/layout/ticketLayout.go
+++ b/layout/ticketLayout.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"strconv"
 
-	"github.com/aquasecurity/postee/data"
+	"github.com/aquasecurity/postee/v2/data"
 )
 
 func GenTestDescription(provider LayoutProvider, raw string) string {

--- a/layout/vulnerabilities.go
+++ b/layout/vulnerabilities.go
@@ -2,8 +2,9 @@ package layout
 
 import (
 	"bytes"
-	"github.com/aquasecurity/postee/data"
 	"strings"
+
+	"github.com/aquasecurity/postee/v2/data"
 )
 
 const empty = "none"

--- a/main.go
+++ b/main.go
@@ -8,10 +8,10 @@ import (
 	"runtime"
 	"syscall"
 
-	"github.com/aquasecurity/postee/dbservice"
-	"github.com/aquasecurity/postee/router"
-	"github.com/aquasecurity/postee/utils"
-	"github.com/aquasecurity/postee/webserver"
+	"github.com/aquasecurity/postee/v2/dbservice"
+	"github.com/aquasecurity/postee/v2/router"
+	"github.com/aquasecurity/postee/v2/utils"
+	"github.com/aquasecurity/postee/v2/webserver"
 	"github.com/spf13/cobra"
 )
 

--- a/msgservice/aggregatebytime_test.go
+++ b/msgservice/aggregatebytime_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/aquasecurity/postee/data"
-	"github.com/aquasecurity/postee/dbservice"
-	"github.com/aquasecurity/postee/outputs"
-	"github.com/aquasecurity/postee/routes"
+	"github.com/aquasecurity/postee/v2/data"
+	"github.com/aquasecurity/postee/v2/dbservice"
+	"github.com/aquasecurity/postee/v2/outputs"
+	"github.com/aquasecurity/postee/v2/routes"
 )
 
 func TestAggregateByTimeout(t *testing.T) {

--- a/msgservice/aggregatescan_test.go
+++ b/msgservice/aggregatescan_test.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/aquasecurity/postee/dbservice"
-	"github.com/aquasecurity/postee/routes"
+	"github.com/aquasecurity/postee/v2/dbservice"
+	"github.com/aquasecurity/postee/v2/routes"
 )
 
 func TestAggregateIssuesPerTicket(t *testing.T) {

--- a/msgservice/applicationscopeowner_test.go
+++ b/msgservice/applicationscopeowner_test.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/aquasecurity/postee/dbservice"
-	"github.com/aquasecurity/postee/routes"
+	"github.com/aquasecurity/postee/v2/dbservice"
+	"github.com/aquasecurity/postee/v2/routes"
 )
 
 var (

--- a/msgservice/getuniqueid_test.go
+++ b/msgservice/getuniqueid_test.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/aquasecurity/postee/dbservice"
-	"github.com/aquasecurity/postee/routes"
+	"github.com/aquasecurity/postee/v2/dbservice"
+	"github.com/aquasecurity/postee/v2/routes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/msgservice/msghandling.go
+++ b/msgservice/msghandling.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aquasecurity/postee/data"
-	"github.com/aquasecurity/postee/dbservice"
-	"github.com/aquasecurity/postee/outputs"
-	"github.com/aquasecurity/postee/regoservice"
-	"github.com/aquasecurity/postee/routes"
+	"github.com/aquasecurity/postee/v2/data"
+	"github.com/aquasecurity/postee/v2/dbservice"
+	"github.com/aquasecurity/postee/v2/outputs"
+	"github.com/aquasecurity/postee/v2/regoservice"
+	"github.com/aquasecurity/postee/v2/routes"
 )
 
 type MsgService struct {

--- a/msgservice/msgservice_mocks_test.go
+++ b/msgservice/msgservice_mocks_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/aquasecurity/postee/formatting"
-	"github.com/aquasecurity/postee/layout"
+	"github.com/aquasecurity/postee/v2/formatting"
+	"github.com/aquasecurity/postee/v2/layout"
 )
 
 var (

--- a/msgservice/msgservice_scan_test.go
+++ b/msgservice/msgservice_scan_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aquasecurity/postee/data"
-	"github.com/aquasecurity/postee/formatting"
-	"github.com/aquasecurity/postee/layout"
+	"github.com/aquasecurity/postee/v2/data"
+	"github.com/aquasecurity/postee/v2/formatting"
+	"github.com/aquasecurity/postee/v2/layout"
 )
 
 var (

--- a/msgservice/msgservice_test.go
+++ b/msgservice/msgservice_test.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/aquasecurity/postee/dbservice"
-	"github.com/aquasecurity/postee/routes"
+	"github.com/aquasecurity/postee/v2/dbservice"
+	"github.com/aquasecurity/postee/v2/routes"
 )
 
 var (

--- a/msgservice/regocriteria_test.go
+++ b/msgservice/regocriteria_test.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/aquasecurity/postee/dbservice"
-	"github.com/aquasecurity/postee/routes"
+	"github.com/aquasecurity/postee/v2/dbservice"
+	"github.com/aquasecurity/postee/v2/routes"
 )
 
 var (

--- a/msgservice/scheduler.go
+++ b/msgservice/scheduler.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/aquasecurity/postee/data"
-	"github.com/aquasecurity/postee/outputs"
-	"github.com/aquasecurity/postee/routes"
+	"github.com/aquasecurity/postee/v2/data"
+	"github.com/aquasecurity/postee/v2/outputs"
+	"github.com/aquasecurity/postee/v2/routes"
 )
 
 var getTicker = func(seconds int) *time.Ticker {

--- a/msgservice/scheduler_test.go
+++ b/msgservice/scheduler_test.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/aquasecurity/postee/outputs"
-	"github.com/aquasecurity/postee/routes"
+	"github.com/aquasecurity/postee/v2/outputs"
+	"github.com/aquasecurity/postee/v2/routes"
 )
 
 func TestSheduler(t *testing.T) {

--- a/outputs/email.go
+++ b/outputs/email.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aquasecurity/postee/formatting"
-	"github.com/aquasecurity/postee/layout"
+	"github.com/aquasecurity/postee/v2/formatting"
+	"github.com/aquasecurity/postee/v2/layout"
 )
 
 var (

--- a/outputs/jira.go
+++ b/outputs/jira.go
@@ -8,8 +8,8 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/aquasecurity/postee/formatting"
-	"github.com/aquasecurity/postee/layout"
+	"github.com/aquasecurity/postee/v2/formatting"
+	"github.com/aquasecurity/postee/v2/layout"
 
 	"net/http"
 	"net/url"

--- a/outputs/message.go
+++ b/outputs/message.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"strings"
 
-	"github.com/aquasecurity/postee/layout"
+	"github.com/aquasecurity/postee/v2/layout"
 )
 
 func buildShortMessage(server, urls string, provider layout.LayoutProvider) string {

--- a/outputs/plugin.go
+++ b/outputs/plugin.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/aquasecurity/postee/layout"
+	"github.com/aquasecurity/postee/v2/layout"
 )
 
 const (

--- a/outputs/servicenow.go
+++ b/outputs/servicenow.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/aquasecurity/postee/formatting"
-	"github.com/aquasecurity/postee/layout"
-	servicenow "github.com/aquasecurity/postee/servicenow"
+	"github.com/aquasecurity/postee/v2/formatting"
+	"github.com/aquasecurity/postee/v2/layout"
+	servicenow "github.com/aquasecurity/postee/v2/servicenow"
 )
 
 type ServiceNowOutput struct {

--- a/outputs/slack.go
+++ b/outputs/slack.go
@@ -6,11 +6,11 @@ import (
 	"log"
 	"strings"
 
-	"github.com/aquasecurity/postee/data"
-	"github.com/aquasecurity/postee/formatting"
-	"github.com/aquasecurity/postee/layout"
+	"github.com/aquasecurity/postee/v2/data"
+	"github.com/aquasecurity/postee/v2/formatting"
+	"github.com/aquasecurity/postee/v2/layout"
 
-	slackAPI "github.com/aquasecurity/postee/slack"
+	slackAPI "github.com/aquasecurity/postee/v2/slack"
 )
 
 const (

--- a/outputs/splunk.go
+++ b/outputs/splunk.go
@@ -10,9 +10,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/aquasecurity/postee/data"
-	"github.com/aquasecurity/postee/formatting"
-	"github.com/aquasecurity/postee/layout"
+	"github.com/aquasecurity/postee/v2/data"
+	"github.com/aquasecurity/postee/v2/formatting"
+	"github.com/aquasecurity/postee/v2/layout"
 )
 
 const defaultSizeLimit = 10000

--- a/outputs/stdout.go
+++ b/outputs/stdout.go
@@ -2,9 +2,10 @@ package outputs
 
 import (
 	"fmt"
-	"github.com/aquasecurity/postee/formatting"
-	"github.com/aquasecurity/postee/layout"
 	"os"
+
+	"github.com/aquasecurity/postee/v2/formatting"
+	"github.com/aquasecurity/postee/v2/layout"
 )
 
 type StdoutOutput struct {

--- a/outputs/teams.go
+++ b/outputs/teams.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/aquasecurity/postee/formatting"
-	"github.com/aquasecurity/postee/layout"
-	"github.com/aquasecurity/postee/utils"
+	"github.com/aquasecurity/postee/v2/formatting"
+	"github.com/aquasecurity/postee/v2/layout"
+	"github.com/aquasecurity/postee/v2/utils"
 
-	msteams "github.com/aquasecurity/postee/teams"
+	msteams "github.com/aquasecurity/postee/v2/teams"
 )
 
 const (

--- a/outputs/webhook.go
+++ b/outputs/webhook.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/aquasecurity/postee/formatting"
-	"github.com/aquasecurity/postee/layout"
+	"github.com/aquasecurity/postee/v2/formatting"
+	"github.com/aquasecurity/postee/v2/layout"
 )
 
 type WebhookOutput struct {

--- a/regoservice/eval.go
+++ b/regoservice/eval.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aquasecurity/postee/data"
+	"github.com/aquasecurity/postee/v2/data"
 	"github.com/open-policy-agent/opa/rego"
 )
 

--- a/router/builders.go
+++ b/router/builders.go
@@ -3,7 +3,7 @@ package router
 import (
 	"strings"
 
-	"github.com/aquasecurity/postee/outputs"
+	"github.com/aquasecurity/postee/v2/outputs"
 )
 
 func buildStdoutOutput(sourceSettings *OutputSettings) *outputs.StdoutOutput {

--- a/router/loads_test.go
+++ b/router/loads_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aquasecurity/postee/data"
-	"github.com/aquasecurity/postee/dbservice"
-	"github.com/aquasecurity/postee/msgservice"
-	"github.com/aquasecurity/postee/outputs"
-	"github.com/aquasecurity/postee/routes"
+	"github.com/aquasecurity/postee/v2/data"
+	"github.com/aquasecurity/postee/v2/dbservice"
+	"github.com/aquasecurity/postee/v2/msgservice"
+	"github.com/aquasecurity/postee/v2/outputs"
+	"github.com/aquasecurity/postee/v2/routes"
 )
 
 var (

--- a/router/router.go
+++ b/router/router.go
@@ -12,14 +12,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aquasecurity/postee/data"
-	"github.com/aquasecurity/postee/dbservice"
-	"github.com/aquasecurity/postee/formatting"
-	"github.com/aquasecurity/postee/msgservice"
-	"github.com/aquasecurity/postee/outputs"
-	"github.com/aquasecurity/postee/regoservice"
-	"github.com/aquasecurity/postee/routes"
-	"github.com/aquasecurity/postee/utils"
+	"github.com/aquasecurity/postee/v2/data"
+	"github.com/aquasecurity/postee/v2/dbservice"
+	"github.com/aquasecurity/postee/v2/formatting"
+	"github.com/aquasecurity/postee/v2/msgservice"
+	"github.com/aquasecurity/postee/v2/outputs"
+	"github.com/aquasecurity/postee/v2/regoservice"
+	"github.com/aquasecurity/postee/v2/routes"
+	"github.com/aquasecurity/postee/v2/utils"
 )
 
 const (

--- a/router/tenants.go
+++ b/router/tenants.go
@@ -1,7 +1,7 @@
 package router
 
 import (
-	"github.com/aquasecurity/postee/routes"
+	"github.com/aquasecurity/postee/v2/routes"
 )
 
 type TenantSettings struct {

--- a/servicenow/insert_table.go
+++ b/servicenow/insert_table.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"github.com/aquasecurity/postee/utils"
 	"net/http"
+
+	"github.com/aquasecurity/postee/v2/utils"
 )
 
 func InsertRecordToTable(user, password, instance, table string, content []byte) error {

--- a/teams/teams_requests.go
+++ b/teams/teams_requests.go
@@ -3,9 +3,10 @@ package teams_api
 import (
 	"bytes"
 	"fmt"
-	"github.com/aquasecurity/postee/utils"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/aquasecurity/postee/v2/utils"
 )
 
 func CreateMessageByWebhook(webhook, content string) error {

--- a/webserver/reload.go
+++ b/webserver/reload.go
@@ -3,7 +3,7 @@ package webserver
 import (
 	"net/http"
 
-	"github.com/aquasecurity/postee/router"
+	"github.com/aquasecurity/postee/v2/router"
 )
 
 func (web *WebServer) reload(w http.ResponseWriter, r *http.Request) {

--- a/webserver/tenant.go
+++ b/webserver/tenant.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/aquasecurity/postee/router"
-	"github.com/aquasecurity/postee/utils"
+	"github.com/aquasecurity/postee/v2/router"
+	"github.com/aquasecurity/postee/v2/utils"
 	"github.com/gorilla/mux"
 )
 

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/aquasecurity/postee/dbservice"
-	"github.com/aquasecurity/postee/router"
-	"github.com/aquasecurity/postee/utils"
+	"github.com/aquasecurity/postee/v2/dbservice"
+	"github.com/aquasecurity/postee/v2/router"
+	"github.com/aquasecurity/postee/v2/utils"
 	"github.com/gorilla/mux"
 )
 


### PR DESCRIPTION
unable to get postee v2.x.x now : 
```
➜  go get github.com/aquasecurity/postee
go get: added github.com/aquasecurity/postee v1.1.4
...
➜  go get github.com/aquasecurity/postee/v2    
go get: module github.com/aquasecurity/postee@upgrade found (v1.1.4), but does not contain package github.com/aquasecurity/postee/v2
...
```