### PR TITLE
feat: Introduce Postee Actions

### DIFF
--- a/cfg-actions.yaml
+++ b/cfg-actions.yaml
@@ -14,7 +14,7 @@ routes:
 
 - name: actions-route
   input: contains(input.SigMetadata.ID, "TRC-2")
-  outputs: [my-exec, my-http-get, my-http-post]     # Outputs are serially executed
+  outputs: [my-exec, my-http-get, my-http-post]
   template: raw-json
 
 # Templates are used to format a message
@@ -51,4 +51,4 @@ outputs:
   headers:                            # Optional. Headers to pass in for the request.
     "Foo": ["bar", "baz"]
   timeout: 10s                        # Optional. Timeout value in XX(s,m,h)
-  body: "hello world"                 # Optional. Body of the HTTP request
+  bodyFile: tracee.event.logs         # Optional. Body of the HTTP request

--- a/cfg-actions.yaml
+++ b/cfg-actions.yaml
@@ -14,7 +14,7 @@ routes:
 
 - name: actions-route
   input: contains(input.SigMetadata.ID, "TRC-2")
-  outputs: [my-http-post]
+  outputs: [my-exec, my-http-get, my-http-post]     # Outputs are serially executed
   template: raw-json
 
 # Templates are used to format a message
@@ -34,10 +34,21 @@ outputs:
   enable: true
   input-file: exec-test.sh            # Required. Specify the path to the script to run
 
+- name: my-http-get
+  type: http
+  enable: true
+  url: "https://my-fancy-url.com"     # Required. URL of the HTTP Request
+  method: GET                         # Required. Method to use. CONNECT is not supported at this time
+  headers:                            # Optional. Headers to pass in for the request
+    "Foo": ["bar", "baz"]
+  timeout: 1s                         # Optional. Timeout value in XX(s,m,h)
+
 - name: my-http-post
   type: http
   enable: true
-  url: "https://google.com"           # Required. URL of the HTTP Request
-  method: post                        # Required. Method to use. CONNECT is not supported at this time
+  url: "https://my-fancy-url.com"     # Required. URL of the HTTP Request
+  method: POST                        # Required. Method to use. CONNECT is not supported at this time
+  headers:                            # Optional. Headers to pass in for the request.
+    "Foo": ["bar", "baz"]
   timeout: 10s                        # Optional. Timeout value in XX(s,m,h)
   body: "hello world"                 # Optional. Body of the HTTP request

--- a/cfg-actions.yaml
+++ b/cfg-actions.yaml
@@ -1,0 +1,35 @@
+# The configuration file contains a general settings section,
+# routes, templates and outputs sections.
+
+name: tenant            #  The tenant name
+aqua-server:            #  URL of Aqua Server for links. E.g. https://myserver.aquasec.com
+max-db-size: 1000       #  Max size of DB in MB. if empty then unlimited
+db-verify-interval: 1   #  How often to check the DB size. By default, Postee checks every 1 hour
+
+# Routes are used to define how to handle an incoming message
+routes:
+- name: stdout
+  outputs: [ stdout ]
+  template: raw-json
+
+- name: exec-route
+  input: contains(input.SigMetadata.ID, "TRC-2")
+  outputs: [my-exec]
+  template: raw-json
+
+# Templates are used to format a message
+templates:
+- name: raw-json                        # route message "As Is" to external webhook
+  rego-package: postee.rawmessage.json
+
+# Outputs are target services that should consume the messages
+outputs:
+- name: stdout
+  type: stdout
+  enable: true
+
+# Define a custom output of exec action, that can take params.
+- name: my-exec
+  type: exec
+  enable: true
+  input-file: exec-test.sh # Mandatory. Specify the path to the script to run.

--- a/cfg-actions.yaml
+++ b/cfg-actions.yaml
@@ -32,7 +32,8 @@ outputs:
 - name: my-exec
   type: exec
   enable: true
-  input-file: exec-test.sh            # Required. Specify the path to the script to run
+  env: ["MY_ENV_VAR=foo_bar_baz", "MY_KEY=secret"]     # Optional. Any environment variables to pass in
+  input-file: exec-test.sh                             # Required. Specify the path to the script to run
 
 - name: my-http-get
   type: http

--- a/cfg-actions.yaml
+++ b/cfg-actions.yaml
@@ -12,9 +12,9 @@ routes:
   outputs: [ stdout ]
   template: raw-json
 
-- name: exec-route
+- name: actions-route
   input: contains(input.SigMetadata.ID, "TRC-2")
-  outputs: [my-exec]
+  outputs: [my-http-post]
   template: raw-json
 
 # Templates are used to format a message
@@ -32,4 +32,12 @@ outputs:
 - name: my-exec
   type: exec
   enable: true
-  input-file: exec-test.sh # Mandatory. Specify the path to the script to run.
+  input-file: exec-test.sh            # Required. Specify the path to the script to run
+
+- name: my-http-post
+  type: http
+  enable: true
+  url: "https://google.com"           # Required. URL of the HTTP Request
+  method: post                        # Required. Method to use. CONNECT is not supported at this time
+  timeout: 10s                        # Optional. Timeout value in XX(s,m,h)
+  body: "hello world"                 # Optional. Body of the HTTP request

--- a/outputs/exec.go
+++ b/outputs/exec.go
@@ -14,16 +14,16 @@ type ExecClient struct {
 	InputFile string
 }
 
-func (e ExecClient) GetName() string {
+func (e *ExecClient) GetName() string {
 	return e.Name
 }
 
-func (e ExecClient) Init() error {
+func (e *ExecClient) Init() error {
 	e.Name = "Exec Output"
 	return nil
 }
 
-func (e ExecClient) Send(m map[string]string) error {
+func (e *ExecClient) Send(m map[string]string) error {
 	// Set Postee event to be available inside the execution shell
 	cmd := exec.Command("/bin/sh", e.InputFile)
 	cmd.Env = os.Environ()
@@ -39,10 +39,11 @@ func (e ExecClient) Send(m map[string]string) error {
 	return nil
 }
 
-func (e ExecClient) Terminate() error {
+func (e *ExecClient) Terminate() error {
+	log.Printf("Exec output terminated\n")
 	return nil
 }
 
-func (e ExecClient) GetLayoutProvider() layout.LayoutProvider {
+func (e *ExecClient) GetLayoutProvider() layout.LayoutProvider {
 	return nil
 }

--- a/outputs/exec.go
+++ b/outputs/exec.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/aquasecurity/postee/layout"
+	"github.com/aquasecurity/postee/v2/layout"
 )
 
 type execCmd = func(string, ...string) *exec.Cmd

--- a/outputs/exec.go
+++ b/outputs/exec.go
@@ -40,7 +40,7 @@ func (e *ExecClient) Send(m map[string]string) error {
 
 	var err error
 	if e.Output, err = cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("error while executing script: %s", err.Error())
+		return fmt.Errorf("error while executing script: %w", err)
 	}
 	log.Println("execution output: ", "len: ", len(e.Output), "out: ", string(e.Output))
 	return nil

--- a/outputs/exec.go
+++ b/outputs/exec.go
@@ -1,0 +1,48 @@
+package outputs
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/aquasecurity/postee/layout"
+)
+
+type ExecClient struct {
+	Name      string
+	InputFile string
+}
+
+func (e ExecClient) GetName() string {
+	return e.Name
+}
+
+func (e ExecClient) Init() error {
+	e.Name = "Exec Output"
+	return nil
+}
+
+func (e ExecClient) Send(m map[string]string) error {
+	// Set Postee event to be available inside the execution shell
+	cmd := exec.Command("/bin/sh", e.InputFile)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("POSTEE_EVENT=%s", m["description"]))
+
+	var out []byte
+	var err error
+	if out, err = cmd.CombinedOutput(); err != nil {
+		log.Printf("error while executing script: %s", err.Error())
+		return err
+	}
+	log.Println("execution output: ", "len: ", len(out), "out: ", string(out))
+	return nil
+}
+
+func (e ExecClient) Terminate() error {
+	return nil
+}
+
+func (e ExecClient) GetLayoutProvider() layout.LayoutProvider {
+	return nil
+}

--- a/outputs/exec.go
+++ b/outputs/exec.go
@@ -30,12 +30,13 @@ func (e *ExecClient) Init() error {
 }
 
 func (e *ExecClient) Send(m map[string]string) error {
-	e.Env = os.Environ()
-	e.Env = append(e.Env, fmt.Sprintf("POSTEE_EVENT=%s", m["description"]))
+	envVars := os.Environ()
+	envVars = append(envVars, e.Env...)
+	envVars = append(envVars, fmt.Sprintf("POSTEE_EVENT=%s", m["description"]))
 
 	// Set Postee event to be available inside the execution shell
 	cmd := e.ExecCmd("/bin/sh", e.InputFile)
-	cmd.Env = append(cmd.Env, e.Env...)
+	cmd.Env = append(cmd.Env, envVars...)
 
 	var err error
 	if e.Output, err = cmd.CombinedOutput(); err != nil {

--- a/outputs/exec.go
+++ b/outputs/exec.go
@@ -30,7 +30,7 @@ func (e *ExecClient) Init() error {
 }
 
 func (e *ExecClient) Send(m map[string]string) error {
-	e.Env = append(e.Env, os.Environ()...)
+	e.Env = os.Environ()
 	e.Env = append(e.Env, fmt.Sprintf("POSTEE_EVENT=%s", m["description"]))
 
 	// Set Postee event to be available inside the execution shell

--- a/outputs/exec_test.go
+++ b/outputs/exec_test.go
@@ -44,19 +44,24 @@ func TestExecClient_Send(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { os.RemoveAll(f.Name()) }()
 		f.WriteString(`#!/bin/sh
-echo "foo"`)
+echo "foo"
+echo $POSTEE_EVENT
+echo $INPUT_ENV`)
 
 		ec := ExecClient{
 			ExecCmd:   exec.Command,
 			InputFile: f.Name(),
+			Env:       []string{"INPUT_ENV=input foo env var"},
 		}
 		require.NoError(t, ec.Send(map[string]string{
 			"description": "foo bar baz env variable",
 		}))
 
 		assert.Equal(t, `foo
+foo bar baz env variable
+input foo env var
 `, string(ec.Output))
-		assert.Contains(t, ec.Env, "POSTEE_EVENT=foo bar baz env variable")
+		assert.Equal(t, ec.Env, []string{"INPUT_ENV=input foo env var"})
 	})
 
 	t.Run("sad path - exec fails", func(t *testing.T) {

--- a/outputs/exec_test.go
+++ b/outputs/exec_test.go
@@ -43,7 +43,7 @@ func TestExecClient_Send(t *testing.T) {
 		f, err := ioutil.TempFile("", "TestExecClient_Send-*")
 		require.NoError(t, err)
 		defer func() { os.RemoveAll(f.Name()) }()
-		f.WriteString(`#!/bin/sh
+		_, _ = f.WriteString(`#!/bin/sh
 echo "foo"
 echo $POSTEE_EVENT
 echo $INPUT_ENV`)

--- a/outputs/exec_test.go
+++ b/outputs/exec_test.go
@@ -1,0 +1,71 @@
+package outputs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fakeExecCmdFailure(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestShellProcessFail", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_TEST_PROCESS=1"}
+	return cmd
+}
+
+func TestShellProcessFail(t *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprint(os.Stderr, "failure")
+	os.Exit(1)
+}
+
+func TestExecClient_Init(t *testing.T) {
+	ec := ExecClient{}
+	require.NoError(t, ec.Init())
+}
+
+func TestExecClient_GetName(t *testing.T) {
+	ec := ExecClient{}
+	require.NoError(t, ec.Init())
+	require.Equal(t, "Exec Output", ec.GetName())
+}
+
+func TestExecClient_Send(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		f, err := ioutil.TempFile("", "TestExecClient_Send-*")
+		require.NoError(t, err)
+		defer func() { os.RemoveAll(f.Name()) }()
+		f.WriteString(`#!/bin/sh
+echo "foo"`)
+
+		ec := ExecClient{
+			ExecCmd:   exec.Command,
+			InputFile: f.Name(),
+		}
+		require.NoError(t, ec.Send(map[string]string{
+			"description": "foo bar baz env variable",
+		}))
+
+		assert.Equal(t, `foo
+`, string(ec.Output))
+		assert.Contains(t, ec.Env, "POSTEE_EVENT=foo bar baz env variable")
+	})
+
+	t.Run("sad path - exec fails", func(t *testing.T) {
+		ec := ExecClient{
+			ExecCmd: fakeExecCmdFailure,
+		}
+		require.EqualError(t, ec.Send(map[string]string{
+			"description": "foo bar baz",
+		}), "error while executing script: exit status 1")
+	})
+
+}

--- a/outputs/http.go
+++ b/outputs/http.go
@@ -25,10 +25,13 @@ func (hc *HTTPClient) GetName() string {
 }
 
 func (hc *HTTPClient) Init() error {
+	hc.Name = "HTTP Output"
 	return nil
 }
 
 func (hc HTTPClient) Send(m map[string]string) error {
+	hc.Headers["POSTEE_EVENT"] = []string{m["description"]} // preserve and transmit postee header
+
 	resp, err := hc.Client.Do(&http.Request{
 		Method: hc.Method,
 		URL:    hc.URL,
@@ -46,7 +49,7 @@ func (hc HTTPClient) Send(m map[string]string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("http status NOT OK: %d, response: %s", resp.StatusCode, string(b))
+		return fmt.Errorf("http status NOT OK: HTTP %d %s, response: %s", resp.StatusCode, http.StatusText(resp.StatusCode), string(b))
 	}
 
 	log.Printf("http execution to url %s successful", hc.URL)

--- a/outputs/http.go
+++ b/outputs/http.go
@@ -30,12 +30,13 @@ func (hc *HTTPClient) Init() error {
 }
 
 func (hc HTTPClient) Send(m map[string]string) error {
-	hc.Headers["POSTEE_EVENT"] = []string{m["description"]} // preserve and transmit postee header
+	headers := hc.Headers
+	headers["POSTEE_EVENT"] = []string{m["description"]} // preserve and transmit postee header
 
 	resp, err := hc.Client.Do(&http.Request{
 		Method: hc.Method,
 		URL:    hc.URL,
-		Header: hc.Headers,
+		Header: headers,
 		Body:   io.NopCloser(strings.NewReader(hc.Body)),
 	})
 	if err != nil {

--- a/outputs/http.go
+++ b/outputs/http.go
@@ -48,7 +48,7 @@ func (hc HTTPClient) Send(m map[string]string) error {
 		return fmt.Errorf("unable to read HTTP response: %s", err.Error())
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return fmt.Errorf("http status NOT OK: HTTP %d %s, response: %s", resp.StatusCode, http.StatusText(resp.StatusCode), string(b))
 	}
 

--- a/outputs/http.go
+++ b/outputs/http.go
@@ -50,7 +50,7 @@ func (hc HTTPClient) Send(m map[string]string) error {
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("unable to read HTTP response: %s", err.Error())
+		return fmt.Errorf("unable to read HTTP response: %w", err)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {

--- a/outputs/http.go
+++ b/outputs/http.go
@@ -1,0 +1,59 @@
+package outputs
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/aquasecurity/postee/layout"
+)
+
+type HTTPClient struct {
+	Name    string
+	URL     *url.URL
+	Method  string
+	Body    string
+	Timeout time.Duration
+}
+
+func (hc *HTTPClient) GetName() string {
+	return hc.Name
+}
+
+func (hc *HTTPClient) Init() error {
+	hc.Name = "HTTP Client"
+	return nil
+}
+
+func (hc HTTPClient) Send(m map[string]string) error {
+	c := http.Client{
+		Timeout: hc.Timeout,
+	}
+
+	resp, err := c.Do(&http.Request{
+		Method: hc.Method,
+		URL:    hc.URL,
+		Header: nil, // TODO: Support adding headers
+		Body:   io.NopCloser(bytes.NewBufferString(hc.Body)),
+	})
+	if err != nil {
+		log.Println("error during HTTP Client execution: ", err.Error())
+		return err
+	}
+
+	b, _ := io.ReadAll(resp.Body)
+	log.Println(">>>>>>>>>> body: ", string(b))
+	return nil
+}
+
+func (hc HTTPClient) Terminate() error {
+	log.Printf("HTTP output terminated\n")
+	return nil
+}
+
+func (hc HTTPClient) GetLayoutProvider() layout.LayoutProvider {
+	return nil
+}

--- a/outputs/http.go
+++ b/outputs/http.go
@@ -30,7 +30,11 @@ func (hc *HTTPClient) Init() error {
 }
 
 func (hc HTTPClient) Send(m map[string]string) error {
-	headers := hc.Headers
+	headers := make(map[string][]string)
+	for k, v := range hc.Headers {
+		headers[k] = v
+	}
+
 	headers["POSTEE_EVENT"] = []string{m["description"]} // preserve and transmit postee header
 
 	resp, err := hc.Client.Do(&http.Request{

--- a/outputs/http.go
+++ b/outputs/http.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/aquasecurity/postee/layout"
+	"github.com/aquasecurity/postee/v2/layout"
 )
 
 type HTTPClient struct {

--- a/outputs/http.go
+++ b/outputs/http.go
@@ -7,17 +7,16 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/aquasecurity/postee/layout"
 )
 
 type HTTPClient struct {
 	Name    string
+	Client  http.Client
 	URL     *url.URL
 	Method  string
 	Body    string
-	Timeout time.Duration
 	Headers map[string][]string
 }
 
@@ -26,16 +25,11 @@ func (hc *HTTPClient) GetName() string {
 }
 
 func (hc *HTTPClient) Init() error {
-	hc.Name = "HTTP Client"
 	return nil
 }
 
 func (hc HTTPClient) Send(m map[string]string) error {
-	c := http.Client{
-		Timeout: hc.Timeout,
-	}
-
-	resp, err := c.Do(&http.Request{
+	resp, err := hc.Client.Do(&http.Request{
 		Method: hc.Method,
 		URL:    hc.URL,
 		Header: hc.Headers,

--- a/outputs/http_test.go
+++ b/outputs/http_test.go
@@ -59,7 +59,7 @@ func TestHTTPClient_Send(t *testing.T) {
 			method: http.MethodGet,
 			testServerFunc: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte("internal server error"))
+				_, _ = w.Write([]byte("internal server error"))
 			},
 			expectedError: "http status NOT OK: HTTP 500 Internal Server Error, response: internal server error",
 		},

--- a/outputs/http_test.go
+++ b/outputs/http_test.go
@@ -35,6 +35,7 @@ func TestHTTPClient_Send(t *testing.T) {
 			name:   "happy path method get",
 			method: http.MethodGet,
 			testServerFunc: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "bar value", r.Header.Get("fookey"))
 				assert.Equal(t, "foo bar baz header", r.Header.Get("POSTEE_EVENT"))
 				fmt.Fprintln(w, "Hello, client")
 			},
@@ -44,6 +45,7 @@ func TestHTTPClient_Send(t *testing.T) {
 			method: http.MethodPost,
 			body:   "foo body",
 			testServerFunc: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "bar value", r.Header.Get("fookey"))
 				assert.Equal(t, "foo bar baz header", r.Header.Get("POSTEE_EVENT"))
 
 				b, _ := ioutil.ReadAll(r.Body)

--- a/outputs/http_test.go
+++ b/outputs/http_test.go
@@ -1,0 +1,95 @@
+package outputs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPClient_Init(t *testing.T) {
+	ec := HTTPClient{}
+	require.NoError(t, ec.Init())
+}
+
+func TestHTTPClient_GetName(t *testing.T) {
+	ec := HTTPClient{}
+	require.NoError(t, ec.Init())
+	require.Equal(t, "HTTP Output", ec.GetName())
+}
+
+func TestHTTPClient_Send(t *testing.T) {
+	testCases := []struct {
+		name           string
+		method         string
+		body           string
+		testServerFunc http.HandlerFunc
+		expectedError  string
+	}{
+		{
+			name:   "happy path method get",
+			method: http.MethodGet,
+			testServerFunc: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "foo bar baz header", r.Header.Get("POSTEE_EVENT"))
+				fmt.Fprintln(w, "Hello, client")
+			},
+		},
+		{
+			name:   "happy path method post",
+			method: http.MethodPost,
+			body:   "foo body",
+			testServerFunc: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "foo bar baz header", r.Header.Get("POSTEE_EVENT"))
+
+				b, _ := ioutil.ReadAll(r.Body)
+				assert.Equal(t, "foo body", string(b))
+
+				fmt.Fprintln(w, "Hello, client")
+			},
+		},
+		{
+			name:   "sad path method get - server unavailable",
+			method: http.MethodGet,
+			testServerFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("internal server error"))
+			},
+			expectedError: "http status NOT OK: HTTP 500 Internal Server Error, response: internal server error",
+		},
+		{
+			name:          "sad path method get - bad url",
+			method:        http.MethodGet,
+			expectedError: `Get "http://path-to-nowhere": dial tcp: lookup path-to-nowhere: no such host`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var testUrl *url.URL
+			if tc.testServerFunc != nil {
+				ts := httptest.NewServer(tc.testServerFunc)
+				testUrl, _ = url.Parse(ts.URL)
+			} else {
+				testUrl, _ = url.Parse("http://path-to-nowhere")
+			}
+
+			ec := HTTPClient{
+				URL:     testUrl,
+				Body:    tc.body,
+				Method:  tc.method,
+				Headers: map[string][]string{"fookey": {"bar value"}},
+			}
+			switch {
+			case tc.expectedError != "":
+				require.EqualError(t, ec.Send(map[string]string{"description": "foo bar baz header"}), tc.expectedError, tc.name)
+			default:
+				require.NoError(t, ec.Send(map[string]string{"description": "foo bar baz header"}), tc.name)
+			}
+		})
+	}
+}

--- a/router/builders.go
+++ b/router/builders.go
@@ -119,12 +119,16 @@ func buildHTTPOutput(sourceSettings *OutputSettings) (*outputs.HTTPClient, error
 		return nil, fmt.Errorf("http action requires a method to be specified")
 	}
 
-	duration, err := time.ParseDuration(sourceSettings.Timeout)
-	if err != nil {
-		return nil, fmt.Errorf("invalid duration specified: %w", err)
-	}
-	if duration == 0 {
-		duration = time.Second * 5
+	var duration time.Duration
+	if len(sourceSettings.Timeout) > 0 {
+		var err error
+		duration, err = time.ParseDuration(sourceSettings.Timeout)
+		if err != nil {
+			return nil, fmt.Errorf("invalid duration specified: %w", err)
+		}
+		if duration == 0 {
+			duration = time.Second * 5
+		}
 	}
 
 	reqUrl, err := url.Parse(sourceSettings.Url)

--- a/router/builders.go
+++ b/router/builders.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -130,12 +131,21 @@ func buildHTTPOutput(sourceSettings *OutputSettings) (*outputs.HTTPClient, error
 		return nil, fmt.Errorf("error building HTTP url: %s", err.Error())
 	}
 
+	var body []byte
+	if len(sourceSettings.BodyFile) > 0 {
+		var err error
+		body, err = ioutil.ReadFile(sourceSettings.BodyFile)
+		if err != nil {
+			return nil, fmt.Errorf("http action unable to specified body-file: %s, err: %s", sourceSettings.BodyFile, err.Error())
+		}
+	}
+
 	return &outputs.HTTPClient{
 		Name:    sourceSettings.Name,
 		Client:  http.Client{Timeout: duration},
 		URL:     reqUrl,
 		Method:  strings.ToUpper(sourceSettings.Method),
-		Body:    sourceSettings.Body,
+		Body:    string(body),
 		Headers: sourceSettings.Headers,
 	}, nil
 }

--- a/router/builders.go
+++ b/router/builders.go
@@ -121,7 +121,7 @@ func buildHTTPOutput(sourceSettings *OutputSettings) (*outputs.HTTPClient, error
 
 	duration, err := time.ParseDuration(sourceSettings.Timeout)
 	if err != nil {
-		return nil, fmt.Errorf("invalid duration specified: %s", err.Error())
+		return nil, fmt.Errorf("invalid duration specified: %w", err)
 	}
 	if duration == 0 {
 		duration = time.Second * 5
@@ -129,7 +129,7 @@ func buildHTTPOutput(sourceSettings *OutputSettings) (*outputs.HTTPClient, error
 
 	reqUrl, err := url.Parse(sourceSettings.Url)
 	if err != nil {
-		return nil, fmt.Errorf("error building HTTP url: %s", err.Error())
+		return nil, fmt.Errorf("error building HTTP url: %w", err)
 	}
 
 	var body []byte
@@ -137,7 +137,7 @@ func buildHTTPOutput(sourceSettings *OutputSettings) (*outputs.HTTPClient, error
 		var err error
 		body, err = ioutil.ReadFile(sourceSettings.BodyFile)
 		if err != nil {
-			return nil, fmt.Errorf("http action unable to specified body-file: %s, err: %s", sourceSettings.BodyFile, err.Error())
+			return nil, fmt.Errorf("http action unable to specified body-file: %s, err: %w", sourceSettings.BodyFile, err)
 		}
 	}
 

--- a/router/builders.go
+++ b/router/builders.go
@@ -109,6 +109,7 @@ func buildJiraOutput(sourceSettings *OutputSettings) *outputs.JiraAPI {
 func buildExecOutput(sourceSettings *OutputSettings) *outputs.ExecClient {
 	return &outputs.ExecClient{
 		Name:      sourceSettings.Name,
+		Env:       sourceSettings.Env,
 		InputFile: sourceSettings.InputFile,
 	}
 }

--- a/router/builders.go
+++ b/router/builders.go
@@ -136,6 +136,7 @@ func buildHTTPOutput(sourceSettings *OutputSettings) (*outputs.HTTPClient, error
 		URL:     reqUrl,
 		Method:  strings.ToUpper(sourceSettings.Method),
 		Body:    sourceSettings.Body,
+		Headers: sourceSettings.Headers,
 		Timeout: duration,
 	}, nil
 }

--- a/router/builders.go
+++ b/router/builders.go
@@ -126,9 +126,8 @@ func buildHTTPOutput(sourceSettings *OutputSettings) (*outputs.HTTPClient, error
 		if err != nil {
 			return nil, fmt.Errorf("invalid duration specified: %w", err)
 		}
-		if duration == 0 {
-			duration = time.Second * 5
-		}
+	} else {
+		duration = time.Second * 5
 	}
 
 	reqUrl, err := url.Parse(sourceSettings.Url)

--- a/router/builders.go
+++ b/router/builders.go
@@ -100,3 +100,10 @@ func buildJiraOutput(sourceSettings *OutputSettings) *outputs.JiraAPI {
 	}
 	return jiraApi
 }
+
+func buildExecOutput(sourceSettings *OutputSettings) *outputs.ExecClient {
+	return &outputs.ExecClient{
+		Name:      sourceSettings.Name,
+		InputFile: sourceSettings.InputFile,
+	}
+}

--- a/router/goldens/test.txt
+++ b/router/goldens/test.txt
@@ -1,0 +1,1 @@
+foo bar baz

--- a/router/initoutputs_test.go
+++ b/router/initoutputs_test.go
@@ -205,6 +205,48 @@ func TestBuildAndInitOtpt(t *testing.T) {
 			false,
 			"*outputs.TeamsOutput",
 		},
+		{
+			"HTTP Action output, with a timeout & body specified",
+			OutputSettings{
+				Method:   "GET",
+				Timeout:  "10s",
+				Url:      "https://foo.bar.com",
+				Name:     "my-http-output",
+				Type:     "http",
+				BodyFile: "goldens/test.txt",
+			},
+			map[string]interface{}{
+				"Name":   "HTTP Output",
+				"Method": "GET",
+				"Body":   "foo bar baz",
+			},
+			false,
+			"*outputs.HTTPClient",
+		},
+		{
+			"HTTP Action output, with a invalid timeout",
+			OutputSettings{
+				Method:  "GET",
+				Timeout: "ten seconds",
+				Type:    "http",
+			},
+			map[string]interface{}{}, true,
+			"<nil>",
+		},
+		{"Exec Action output",
+			OutputSettings{
+				Name:      "my-exec-output",
+				Env:       []string{"foo=bar"},
+				InputFile: "goldens/test.txt",
+				Type:      "exec",
+			},
+			map[string]interface{}{
+				"Name":      "Exec Output",
+				"InputFile": "goldens/test.txt",
+			},
+			false,
+			"*outputs.ExecClient",
+		},
 	}
 	for _, test := range tests {
 		o := BuildAndInitOtpt(&test.outputSettings, "")

--- a/router/initoutputs_test.go
+++ b/router/initoutputs_test.go
@@ -224,6 +224,42 @@ func TestBuildAndInitOtpt(t *testing.T) {
 			"*outputs.HTTPClient",
 		},
 		{
+			"HTTP Action output, with no method specified",
+			OutputSettings{
+				Url:  "https://foo.bar.com",
+				Name: "my-http-output",
+				Type: "http",
+			},
+			map[string]interface{}{},
+			true,
+			"<nil>",
+		},
+		{
+			"HTTP Action output, with invalid url specified",
+			OutputSettings{
+				Method: "get",
+				Url:    "http://[fe80::1%en0]/",
+				Name:   "my-http-output",
+				Type:   "http",
+			},
+			map[string]interface{}{},
+			true,
+			"<nil>",
+		},
+		{
+			"HTTP Action output, with invalid body file specified",
+			OutputSettings{
+				Method:   "GET",
+				Url:      "https://foo.bar.com",
+				Name:     "my-http-output",
+				Type:     "http",
+				BodyFile: "no such body file",
+			},
+			map[string]interface{}{},
+			true,
+			"<nil>",
+		},
+		{
 			"HTTP Action output, with a invalid timeout",
 			OutputSettings{
 				Method:  "GET",
@@ -251,7 +287,7 @@ func TestBuildAndInitOtpt(t *testing.T) {
 	for _, test := range tests {
 		o := BuildAndInitOtpt(&test.outputSettings, "")
 		if test.shouldFail && o != nil {
-			t.Fatalf("No output expected for %s test case", test.caseDesc)
+			t.Fatalf("No output expected for %s test case but was %s", test.caseDesc, o)
 		} else if !test.shouldFail && o == nil {
 			t.Fatalf("Not expected output returned for %s test case", test.caseDesc)
 		}

--- a/router/integrations.go
+++ b/router/integrations.go
@@ -28,7 +28,7 @@ type OutputSettings struct {
 	InstanceName    string              `json:"instance,omitempty"`
 	SizeLimit       int                 `json:"size-limit,omitempty"`
 	InputFile       string              `json:"input-file,omitempty"`
-	Body            string              `json:"body,omitempty"`
+	BodyFile        string              `json:"bodyfile,omitempty"`
 	Method          string              `json:"method,omitempty"`
 	Timeout         string              `json:"timeout,omitempty"`
 	Headers         map[string][]string `json:"headers,omitempty"`

--- a/router/integrations.go
+++ b/router/integrations.go
@@ -27,4 +27,5 @@ type OutputSettings struct {
 	UseMX           bool              `json:"use-mx,omitempty"`
 	InstanceName    string            `json:"instance,omitempty"`
 	SizeLimit       int               `json:"size-limit,omitempty"`
+	InputFile       string            `json:"input-file"`
 }

--- a/router/integrations.go
+++ b/router/integrations.go
@@ -28,6 +28,7 @@ type OutputSettings struct {
 	InstanceName    string              `json:"instance,omitempty"`
 	SizeLimit       int                 `json:"size-limit,omitempty"`
 	InputFile       string              `json:"input-file,omitempty"`
+	Env             []string            `json:"env,omitempty"`
 	BodyFile        string              `json:"bodyfile,omitempty"`
 	Method          string              `json:"method,omitempty"`
 	Timeout         string              `json:"timeout,omitempty"`

--- a/router/integrations.go
+++ b/router/integrations.go
@@ -1,34 +1,35 @@
 package router
 
 type OutputSettings struct {
-	Name            string            `json:"name,omitempty"`
-	Type            string            `json:"type,omitempty"`
-	Enable          bool              `json:"enable,omitempty"`
-	Url             string            `json:"url,omitempty"`
-	User            string            `json:"user,omitempty"`
-	Password        string            `json:"password,omitempty"`
-	TlsVerify       bool              `json:"tls-verify,omitempty"`
-	ProjectKey      string            `json:"project-key,omitempty" structs:"project-key,omitempty"`
-	IssueType       string            `json:"issuetype" structs:"issuetype"`
-	BoardName       string            `json:"board,omitempty" structs:"board,omitempty"`
-	Priority        string            `json:"priority,omitempty"`
-	Assignee        []string          `json:"assignee,omitempty"`
-	Summary         string            `json:"summary,omitempty"`
-	FixVersions     []string          `json:"fix-versions,omitempty"`
-	AffectsVersions []string          `json:"affects-versions,omitempty"`
-	Labels          []string          `json:"labels,omitempty"`
-	Sprint          string            `json:"sprint,omitempty"`
-	Unknowns        map[string]string `json:"unknowns" structs:"unknowns,omitempty"`
-	Host            string            `json:"host,omitempty"`
-	Port            int               `json:"port,omitempty"`
-	Recipients      []string          `json:"recipients,omitempty"`
-	Sender          string            `json:"sender,omitempty"`
-	Token           string            `json:"token,omitempty"`
-	UseMX           bool              `json:"use-mx,omitempty"`
-	InstanceName    string            `json:"instance,omitempty"`
-	SizeLimit       int               `json:"size-limit,omitempty"`
-	InputFile       string            `json:"input-file,omitempty"`
-	Body            string            `json:"body,omitempty"`
-	Method          string            `json:"method,omitempty"`
-	Timeout         string            `json:"timeout,omitempty"`
+	Name            string              `json:"name,omitempty"`
+	Type            string              `json:"type,omitempty"`
+	Enable          bool                `json:"enable,omitempty"`
+	Url             string              `json:"url,omitempty"`
+	User            string              `json:"user,omitempty"`
+	Password        string              `json:"password,omitempty"`
+	TlsVerify       bool                `json:"tls-verify,omitempty"`
+	ProjectKey      string              `json:"project-key,omitempty" structs:"project-key,omitempty"`
+	IssueType       string              `json:"issuetype" structs:"issuetype"`
+	BoardName       string              `json:"board,omitempty" structs:"board,omitempty"`
+	Priority        string              `json:"priority,omitempty"`
+	Assignee        []string            `json:"assignee,omitempty"`
+	Summary         string              `json:"summary,omitempty"`
+	FixVersions     []string            `json:"fix-versions,omitempty"`
+	AffectsVersions []string            `json:"affects-versions,omitempty"`
+	Labels          []string            `json:"labels,omitempty"`
+	Sprint          string              `json:"sprint,omitempty"`
+	Unknowns        map[string]string   `json:"unknowns" structs:"unknowns,omitempty"`
+	Host            string              `json:"host,omitempty"`
+	Port            int                 `json:"port,omitempty"`
+	Recipients      []string            `json:"recipients,omitempty"`
+	Sender          string              `json:"sender,omitempty"`
+	Token           string              `json:"token,omitempty"`
+	UseMX           bool                `json:"use-mx,omitempty"`
+	InstanceName    string              `json:"instance,omitempty"`
+	SizeLimit       int                 `json:"size-limit,omitempty"`
+	InputFile       string              `json:"input-file,omitempty"`
+	Body            string              `json:"body,omitempty"`
+	Method          string              `json:"method,omitempty"`
+	Timeout         string              `json:"timeout,omitempty"`
+	Headers         map[string][]string `json:"headers,omitempty"`
 }

--- a/router/integrations.go
+++ b/router/integrations.go
@@ -27,5 +27,8 @@ type OutputSettings struct {
 	UseMX           bool              `json:"use-mx,omitempty"`
 	InstanceName    string            `json:"instance,omitempty"`
 	SizeLimit       int               `json:"size-limit,omitempty"`
-	InputFile       string            `json:"input-file"`
+	InputFile       string            `json:"input-file,omitempty"`
+	Body            string            `json:"body,omitempty"`
+	Method          string            `json:"method,omitempty"`
+	Timeout         string            `json:"timeout,omitempty"`
 }

--- a/router/router.go
+++ b/router/router.go
@@ -336,6 +336,8 @@ func BuildAndInitOtpt(settings *OutputSettings, aquaServerUrl string) outputs.Ou
 		plg = buildSplunkOutput(settings)
 	case "stdout":
 		plg = buildStdoutOutput(settings)
+	case "exec":
+		plg = buildExecOutput(settings)
 	default:
 		log.Printf("Output type %q is undefined or empty. Output name is %q.",
 			settings.Type, settings.Name)

--- a/router/router.go
+++ b/router/router.go
@@ -318,6 +318,7 @@ func BuildAndInitOtpt(settings *OutputSettings, aquaServerUrl string) outputs.Ou
 	utils.Debug("Starting Output %q: %q\n", settings.Type, settings.Name)
 
 	var plg outputs.Output
+	var err error
 
 	switch settings.Type {
 	case "jira":
@@ -338,12 +339,19 @@ func BuildAndInitOtpt(settings *OutputSettings, aquaServerUrl string) outputs.Ou
 		plg = buildStdoutOutput(settings)
 	case "exec":
 		plg = buildExecOutput(settings)
+	case "http":
+		plg, err = buildHTTPOutput(settings)
+		if err != nil {
+			log.Println(err.Error())
+			return nil
+		}
 	default:
 		log.Printf("Output type %q is undefined or empty. Output name is %q.",
 			settings.Type, settings.Name)
 		return nil
 	}
-	err := plg.Init()
+
+	err = plg.Init()
 	if err != nil {
 		log.Printf("failed to Init : %v", err)
 	}


### PR DESCRIPTION
This PR introduces Postee Actions, a lightweight (no-code) workflows that allows users to configure Postee to execute ad-hoc but useful post processing steps.

Some use cases include (but are not limited):
1. As a security practitioner, I want to remove a vulnerable image from my node when Trivy scan detects a vulnerability in an image, so that I can keep vulnerable images unavailable for deployment.
2. As a security practitioner, I want to ship Tracee security notifications logs from my node when security events are detected, so that I can build a timelog for forensics purposes.
3. [WIP] As a Kubernetes operator, I want to add labels to my Kubernetes cluster when Starboard detects a vulnerable image in my cluster, so that I can effectively manage vulnerable deployments.

These are some examples of how a user can use Postee Actions.

Signed-off-by: Simar <simar@linux.com>