### PR TITLE
Reuse postgres db conncetion instance

### DIFF
--- a/dbservice/boltdb/boltdb.go
+++ b/dbservice/boltdb/boltdb.go
@@ -42,3 +42,8 @@ func (boltDb *BoltDb) SetNewDbPath(newPath string) error {
 	}
 	return nil
 }
+
+// unimplemented
+func (boltDb *BoltDb) Close() error {
+	return nil
+}

--- a/dbservice/dbservice.go
+++ b/dbservice/dbservice.go
@@ -22,6 +22,7 @@ type DbProvider interface {
 	RegisterPlgnInvctn(name string) error
 	EnsureApiKey() error
 	GetApiKey() (string, error)
+	Close() error
 }
 
 func ConfigureDb(pathToDb, postgresUrl, tenantName string) error {

--- a/dbservice/postgresdb/actions.go
+++ b/dbservice/postgresdb/actions.go
@@ -14,7 +14,6 @@ func (postgresDb *PostgresDb) MayBeStoreMessage(message []byte, messageKey strin
 	if err != nil {
 		return false, err
 	}
-	defer db.Close()
 
 	currentValue := ""
 	sqlQuery := fmt.Sprintf("SELECT messageValue FROM %s WHERE (tenantName=$1 AND messageKey=$2)", dbparam.DbBucketName)

--- a/dbservice/postgresdb/cfgcachesource.go
+++ b/dbservice/postgresdb/cfgcachesource.go
@@ -16,7 +16,7 @@ var UpdateCfgCacheSource = func(postgresDb *PostgresDb, cfgfile string) error {
 	if err != nil {
 		return err
 	}
-	defer db.Close()
+
 	if err := insertCfgCacheSource(db, postgresDb.TenantName, cfgfile); err != nil {
 		return err
 	}
@@ -29,7 +29,7 @@ var GetCfgCacheSource = func(postgresDb *PostgresDb) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer db.Close()
+
 	cfgFile := ""
 	sqlQuery := fmt.Sprintf("SELECT configfile FROM %s WHERE tenantName=$1", dbparam.DbTableCfgCacheSource)
 	if err = db.Get(&cfgFile, sqlQuery, postgresDb.TenantName); err != nil {

--- a/dbservice/postgresdb/checker.go
+++ b/dbservice/postgresdb/checker.go
@@ -19,7 +19,6 @@ func (postgresDb *PostgresDb) CheckSizeLimit() {
 		log.Logger.Errorf("CheckSizeLimit: Can't open db, connectUrl: %s", connectUrl)
 		return
 	}
-	defer db.Close()
 
 	size := 0
 	if err = db.Get(&size, fmt.Sprintf("SELECT pg_total_relation_size('%s');", dbparam.DbBucketName)); err != nil {
@@ -41,7 +40,6 @@ func (postgresDb *PostgresDb) CheckExpiredData() {
 		log.Logger.Errorf("CheckExpiredData: Can't open postgresDb: %v", err)
 		return
 	}
-	defer db.Close()
 
 	max := time.Now().UTC() //remove expired records
 	if err = deleteRowsByTenantNameAndTime(db, postgresDb.TenantName, max); err != nil {

--- a/dbservice/postgresdb/close.go
+++ b/dbservice/postgresdb/close.go
@@ -1,0 +1,10 @@
+package postgresdb
+
+func (postgresDb *PostgresDb) Close() error {
+	db, err := psqlConnect(postgresDb.ConnectUrl)
+	if err != nil {
+		return err
+	}
+
+	return db.Close()
+}

--- a/dbservice/postgresdb/connect_test.go
+++ b/dbservice/postgresdb/connect_test.go
@@ -21,11 +21,3 @@ func TestConnectFuncError(t *testing.T) {
 		t.Errorf("error text connect, expectedError: %v, got: %v", expectedError, err)
 	}
 }
-
-func TestPsqlConnectError(t *testing.T) {
-	expectedError := `missing "=" after "test_trivy_psql_connect_dbName" in connection info string"`
-	_, err := psqlConnect("test_trivy_psql_connect_dbName")
-	if err.Error() != expectedError {
-		t.Errorf("Unexpected error, expected: '%v', got: '%v'", expectedError, err)
-	}
-}

--- a/dbservice/postgresdb/dbaggregator.go
+++ b/dbservice/postgresdb/dbaggregator.go
@@ -18,7 +18,6 @@ func (postgresDb *PostgresDb) AggregateScans(output string,
 	if err != nil {
 		return nil, err
 	}
-	defer db.Close()
 
 	aggregatedScans := make([]map[string]string, 0, scansPerTicket)
 	if len(currentScan) > 0 {

--- a/dbservice/postgresdb/init.go
+++ b/dbservice/postgresdb/init.go
@@ -32,7 +32,6 @@ var InitPostgresDb = func(connectUrl string) error {
 	if err != nil {
 		return err
 	}
-	defer db.Close()
 
 	err = initAllTables(db)
 	if err != nil {

--- a/dbservice/postgresdb/plgstats.go
+++ b/dbservice/postgresdb/plgstats.go
@@ -14,7 +14,6 @@ func (postgresDb *PostgresDb) RegisterPlgnInvctn(name string) error {
 	if err != nil {
 		return err
 	}
-	defer db.Close()
 
 	amount := 0
 	sqlQuery := fmt.Sprintf("SELECT %s FROM %s WHERE (tenantName=$1 AND %s=$2)", "amount", dbparam.DbBucketOutputStats, "outputName")

--- a/dbservice/postgresdb/sharedcfg.go
+++ b/dbservice/postgresdb/sharedcfg.go
@@ -14,7 +14,6 @@ func (postgresDb *PostgresDb) EnsureApiKey() error {
 	if err != nil {
 		return err
 	}
-	defer db.Close()
 
 	apiKey, err := dbparam.GenerateApiKey(32)
 	if err != nil {
@@ -32,7 +31,7 @@ func (postgresDb *PostgresDb) GetApiKey() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer db.Close()
+
 	value := ""
 	sqlQuery := fmt.Sprintf("SELECT %s FROM %s WHERE (tenantName=$1 AND %s=$2)", "value", dbparam.DbBucketSharedConfig, "apikeyname")
 	err = db.Get(&value, sqlQuery, postgresDb.TenantName, apiKeyName)

--- a/router/api_test.go
+++ b/router/api_test.go
@@ -545,7 +545,12 @@ var withPostgresParamsTest = func() error {
 		j, _ := json.Marshal(outputSettings)
 		return string(j), nil
 	}
+
+	savedUpdateCfgCache := postgresdb.UpdateCfgCacheSource
+	postgresdb.UpdateCfgCacheSource = func(postgresDb *postgresdb.PostgresDb, cfgfile string) error { return nil }
+
 	defer func() {
+		postgresdb.UpdateCfgCacheSource = savedUpdateCfgCache
 		postgresdb.InitPostgresDb = savedInitPostgresDb
 		postgresdb.GetCfgCacheSource = savedGetCfgCacheSource
 	}()
@@ -561,7 +566,10 @@ var withPostgresUrlTest = func() error {
 	postgresdb.InitPostgresDb = func(connectUrl string) error { return nil }
 	savedGetCfgCacheSource := postgresdb.GetCfgCacheSource
 	postgresdb.GetCfgCacheSource = func(postgresDb *postgresdb.PostgresDb) (string, error) { return "", nil }
+	savedUpdateCfgCache := postgresdb.UpdateCfgCacheSource
+	postgresdb.UpdateCfgCacheSource = func(postgresDb *postgresdb.PostgresDb, cfgfile string) error { return nil }
 	defer func() {
+		postgresdb.UpdateCfgCacheSource = savedUpdateCfgCache
 		postgresdb.InitPostgresDb = savedInitPostgresDb
 		postgresdb.GetCfgCacheSource = savedGetCfgCacheSource
 	}()

--- a/router/inittemplate_test.go
+++ b/router/inittemplate_test.go
@@ -22,16 +22,20 @@ func TestInitTemplate(t *testing.T) {
 	defaultRegoFolder := "rego-templates"
 	commonRegoFolder := defaultRegoFolder + "/common"
 	testRego := defaultRegoFolder + "/rego1.rego"
-	err := os.Mkdir(defaultRegoFolder, 0777)
-	if err != nil {
-		t.Fatalf("Can't create rego folder: %v", err)
+	if _, err := os.Stat(defaultRegoFolder); os.IsNotExist(err) {
+		err = os.Mkdir(defaultRegoFolder, 0777)
+		if err != nil {
+			t.Fatalf("Can't create rego folder: %v", err)
+		}
 	}
-	err = os.Mkdir(commonRegoFolder, 0777)
-	if err != nil {
-		t.Fatalf("Can't create rego folder: %v", err)
+	if _, err := os.Stat(commonRegoFolder); os.IsNotExist(err) {
+		err = os.Mkdir(commonRegoFolder, 0777)
+		if err != nil {
+			t.Fatalf("Can't create rego folder: %v", err)
+		}
 	}
 
-	err = ioutil.WriteFile(testRego, []byte(regoRule), 0644)
+	err := ioutil.WriteFile(testRego, []byte(regoRule), 0644)
 
 	if err != nil {
 		t.Fatalf("Can't write rego: %v", err)

--- a/router/loads_test.go
+++ b/router/loads_test.go
@@ -289,7 +289,7 @@ func TestApplyPostgresCfg(t *testing.T) {
 		postgresdb.UpdateCfgCacheSource = savedUpdateCfgCacheSource
 	}()
 
-	err := demoCtx.ApplyPostgresCfg("tenantName", postgresUrl, false)
+	err := demoCtx.ApplyPostgresCfg("tenantName", postgresUrl, true)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
This commit includes one change and one addition:
1. Reuse the Postgres DB connection instead of closing and opening for each operation.
2. Connecting to a Postgres server with retry functionality.