### PR TITLE
Evaluate rego rule once for every route (#257)

### DIFF
--- a/msgservice/applicationscopeowner_test.go
+++ b/msgservice/applicationscopeowner_test.go
@@ -43,7 +43,9 @@ func TestApplicationScopeOwner(t *testing.T) {
 	demoEmailOutput.wg.Add(1)
 
 	srv := new(MsgService)
-	srv.MsgHandling([]byte(scnWithOwners), demoEmailOutput, demoRoute, demoInptEval, &srvUrl)
+	if srv.EvaluateRegoRule(demoRoute, []byte(scnWithOwners)) {
+		srv.MsgHandling([]byte(scnWithOwners), demoEmailOutput, demoRoute, demoInptEval, &srvUrl)
+	}
 
 	demoEmailOutput.wg.Wait()
 

--- a/msgservice/getuniqueid_test.go
+++ b/msgservice/getuniqueid_test.go
@@ -112,7 +112,9 @@ func sendInputs(t *testing.T, caseDesc string, inputs []string, uniqueMessagePro
 
 	for _, inp := range inputs {
 		srv := new(MsgService)
-		srv.MsgHandling([]byte(inp), demoEmailOutput, demoRoute, demoInptEval, &srvUrl)
+		if srv.EvaluateRegoRule(demoRoute, []byte(inp)) {
+			srv.MsgHandling([]byte(inp), demoEmailOutput, demoRoute, demoInptEval, &srvUrl)
+		}
 	}
 
 	demoEmailOutput.wg.Wait()

--- a/msgservice/regocriteria_test.go
+++ b/msgservice/regocriteria_test.go
@@ -133,7 +133,9 @@ func validateRegoInput(t *testing.T, caseDesc string, input string, regoCriteria
 	demoEmailOutput.wg.Add(expected)
 
 	srv := new(MsgService)
-	srv.MsgHandling([]byte(input), demoEmailOutput, demoRoute, demoInptEval, &srvUrl)
+	if srv.EvaluateRegoRule(demoRoute, []byte(input)) {
+		srv.MsgHandling([]byte(input), demoEmailOutput, demoRoute, demoInptEval, &srvUrl)
+	}
 
 	demoEmailOutput.wg.Wait()
 

--- a/router/loads_test.go
+++ b/router/loads_test.go
@@ -74,6 +74,7 @@ type ctxWrapper struct {
 	commonRegoFolder   string
 	buff               chan invctn
 }
+
 type invctn struct {
 	outputCls   string
 	templateCls string
@@ -132,6 +133,13 @@ func (ctxWrapper *ctxWrapper) teardown() {
 	dbservice.ChangeDbPath(ctxWrapper.savedDBPath)
 	getScanService = ctxWrapper.savedGetService
 	close(ctxWrapper.buff)
+}
+
+func (ctx *ctxWrapper) EvaluateRegoRule(r *routes.InputRoute, _ []byte) bool {
+	if r.Name == "fail_evaluation" {
+		return false
+	}
+	return true
 }
 
 func TestLoads(t *testing.T) {

--- a/router/router.go
+++ b/router/router.go
@@ -244,6 +244,7 @@ func (ctx *Router) load() error {
 
 type service interface {
 	MsgHandling(input []byte, output outputs.Output, route *routes.InputRoute, inpteval data.Inpteval, aquaServer *string)
+	EvaluateRegoRule(input *routes.InputRoute, in []byte) bool
 }
 
 var getScanService = func() service {
@@ -264,6 +265,11 @@ func (ctx *Router) HandleRoute(routeName string, in []byte) {
 		log.Printf("route %q has no outputs", routeName)
 		return
 	}
+
+	if !getScanService().EvaluateRegoRule(r, in) {
+		return
+	}
+
 	for _, outputName := range r.Outputs {
 		pl, ok := ctx.outputs[outputName]
 		if !ok {


### PR DESCRIPTION
This commit contains code that moves the rego evaluation code to the
route handling process.
At its current implementation, the output handler checks for rego match - this
check is redundant since the output does not effect the matching process.