### PR TITLE
make PosteeUI depend on  postee v2 #264

### DIFF
--- a/ui/backend/dbservice/getplgnstats.go
+++ b/ui/backend/dbservice/getplgnstats.go
@@ -3,7 +3,7 @@ package dbservice
 import (
 	"strconv"
 
-	hookDbService "github.com/aquasecurity/postee/dbservice"
+	hookDbService "github.com/aquasecurity/postee/v2/dbservice"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/ui/backend/go.mod
+++ b/ui/backend/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/postee/ui/backend
 go 1.17
 
 require (
-	github.com/aquasecurity/postee v1.1.5-0.20211210093651-b669cce16033
+	github.com/aquasecurity/postee/v2 v2.0.7
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.1

--- a/ui/backend/go.sum
+++ b/ui/backend/go.sum
@@ -50,8 +50,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aquasecurity/go-jira v0.0.0-20211103111421-b62ce48827be h1:xUasZnauNAn2jY0gfVG+Ro371S31s3SfVUvcjhwIMyI=
 github.com/aquasecurity/go-jira v0.0.0-20211103111421-b62ce48827be/go.mod h1:IHtKzIAdk0t3Xse7rJSY7pJlA8gB7lqY2b4l5WYZYsk=
-github.com/aquasecurity/postee v1.1.5-0.20211210093651-b669cce16033 h1:hYI+KEm1XisE+2ky5nAKhsNdc3vR5NyZ+4pih7KiTu4=
-github.com/aquasecurity/postee v1.1.5-0.20211210093651-b669cce16033/go.mod h1:+5IY6tSMD/HrAoHFKrqwjd46Y9rf+f0pcKPGuF3Y6wM=
+github.com/aquasecurity/postee/v2 v2.0.7 h1:4KpIOKMOoyJl27Lu81Yol4Lp1qqsyMikpld0Wiy1RqI=
+github.com/aquasecurity/postee/v2 v2.0.7/go.mod h1:P7dYLr5HMpdXIQCO5HEMm5xoWjFr5+cX81DaWI3if3k=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/ui/backend/uiserver/config.go
+++ b/ui/backend/uiserver/config.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"os"
 
-	hookDbService "github.com/aquasecurity/postee/dbservice"
-	"github.com/aquasecurity/postee/router"
+	hookDbService "github.com/aquasecurity/postee/v2/dbservice"
+	"github.com/aquasecurity/postee/v2/router"
 )
 
 func (srv *uiServer) getConfig(w http.ResponseWriter, r *http.Request) {

--- a/ui/backend/uiserver/testplg.go
+++ b/ui/backend/uiserver/testplg.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/aquasecurity/postee/layout"
-	"github.com/aquasecurity/postee/router"
+	"github.com/aquasecurity/postee/v2/layout"
+	"github.com/aquasecurity/postee/v2/router"
 )
 
 func (srv *uiServer) testSettings(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
As described in #264. PosteeUI is still depending on an old Postee Versions and a build won't work anymore. 
This will require postee/v2 2.0.7