### PR TITLE
chore: Remove codecov

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,6 +58,3 @@ jobs:
           scan-type: 'config'
           hide-progress: false
           format: 'table'
-
-      - name: Publish Codecov
-        run: bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@
 [release]: https://github.com/aquasecurity/postee/releases
 [docker-pull]: https://img.shields.io/docker/pulls/aquasec/postee?logo=docker&label=docker%20pulls%20%2F%20postee
 [go-doc-img]: https://godoc.org/github.com/aquasecurity/postee?status.svg
-[cov-img]: https://codecov.io/github/aquasecurity/postee/branch/main/graph/badge.svg
-[cov]: https://codecov.io/github/aquasecurity/postee
 [report-card-img]: https://goreportcard.com/badge/github.com/aquasecurity/postee
 [report-card]: https://goreportcard.com/report/github.com/aquasecurity/postee
 [license-img]: https://img.shields.io/badge/License-mit-blue.svg


### PR DESCRIPTION
Recently Codecov has had several availability issues which prevent us from merging PRs on time as the checks get stuck with no recourse to trigger them.


<img width="956" alt="image" src="https://user-images.githubusercontent.com/1254783/153685700-10bbf084-69d1-4378-b81b-6f70471a85de.png">

Signed-off-by: Simar <simar@linux.com>
