### PR TITLE
feat(actions): Support Rego in Kubernetes Action input

### DIFF
--- a/cfg-k8s-actions.yaml
+++ b/cfg-k8s-actions.yaml
@@ -37,6 +37,8 @@ outputs:
   kube-label-selector: "app=nginx-app"              # Required, if specifying labels or annotations.
   kube-actions:
     labels:
-      foo-label: "bar-value"
+      foo-label: "bar-value"                        # Required. Label to add.
+      bar-label: event.input.SigMetadata.ID         # Optional. It is also possible to add labels based on event inputs.
     annotations:
       foo-annotation: "bar-value"
+      bar-annotation: event.input.SigMetadata.ID

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
+	github.com/tidwall/gjson v1.14.0
 	go.etcd.io/bbolt v1.3.6
 	k8s.io/api v0.23.3
 	k8s.io/apimachinery v0.23.3
@@ -51,6 +52,8 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/trivago/tgo v1.0.7 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -935,6 +935,12 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
+github.com/tidwall/gjson v1.14.0 h1:6aeJ0bzojgWLa82gDQHcx3S0Lr/O51I9bJ5nv6JFx5w=
+github.com/tidwall/gjson v1.14.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/outputs/kubernetes.go
+++ b/outputs/kubernetes.go
@@ -2,14 +2,24 @@ package outputs
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aquasecurity/postee/v2/layout"
+	"github.com/tidwall/gjson"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
+)
+
+const (
+	regoInputPrefix = "event.input"
+
+	KubernetesLabelKey      = "labels"
+	KubernetesAnnotationKey = "annotations"
 )
 
 func updateMap(old map[string]string, new map[string]string) map[string]string {
@@ -53,22 +63,45 @@ func (k *KubernetesClient) Init() error {
 	return nil
 }
 
+func (k KubernetesClient) prepareInputs(input map[string]string) map[string]map[string]string {
+	a := make(map[string]map[string]string)
+
+	for key, m := range k.KubeActions {
+		for id, val := range m {
+			var calcVal string
+			if strings.HasPrefix(val, regoInputPrefix) {
+				if ok := json.Valid([]byte(input["description"])); ok { // input is json
+					calcVal = gjson.Get(input["description"], strings.TrimPrefix(val, regoInputPrefix+".")).String()
+				} else {
+					calcVal = input["description"] // input is a string
+				}
+			} else {
+				calcVal = val // no rego to parse
+			}
+			a[key] = map[string]string{id: calcVal}
+		}
+	}
+
+	return a
+}
+
 func (k KubernetesClient) Send(m map[string]string) error {
 	ctx := context.Background()
+	actions := k.prepareInputs(m)
 
 	// TODO: Allow configuring of resource {pod, ds, ...}
 	pods, _ := k.clientset.CoreV1().Pods(k.KubeNamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: k.KubeLabelSelector,
 	})
 	for _, pod := range pods.Items {
-		if len(k.KubeActions["labels"]) > 0 {
+		if len(actions[KubernetesLabelKey]) > 0 {
 			retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				pod, err := k.clientset.CoreV1().Pods(pod.GetNamespace()).Get(ctx, pod.Name, metav1.GetOptions{})
 				if err != nil {
 					return fmt.Errorf("failed to get updated pod for labeling: %s, err: %w", pod.Name, err)
 				}
 
-				labels := updateMap(pod.GetLabels(), k.KubeActions["labels"])
+				labels := updateMap(pod.GetLabels(), actions[KubernetesLabelKey])
 				pod.SetLabels(labels)
 				_, err = k.clientset.CoreV1().Pods(pod.GetNamespace()).Update(ctx, pod, metav1.UpdateOptions{})
 				if err != nil {
@@ -84,14 +117,14 @@ func (k KubernetesClient) Send(m map[string]string) error {
 			}
 		}
 
-		if len(k.KubeActions["annotations"]) > 0 {
+		if len(actions[KubernetesAnnotationKey]) > 0 {
 			retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				pod, err := k.clientset.CoreV1().Pods(pod.GetNamespace()).Get(ctx, pod.Name, metav1.GetOptions{})
 				if err != nil {
 					return fmt.Errorf("failed to get updated pod for annotating: %s, err: %w", pod.Name, err)
 				}
 
-				annotations := updateMap(pod.GetAnnotations(), k.KubeActions["annotations"])
+				annotations := updateMap(pod.GetAnnotations(), actions[KubernetesAnnotationKey])
 				pod.SetAnnotations(annotations)
 				_, err = k.clientset.CoreV1().Pods(pod.GetNamespace()).Update(ctx, pod, metav1.UpdateOptions{})
 				if err != nil {

--- a/regoservice/eval.go
+++ b/regoservice/eval.go
@@ -106,7 +106,7 @@ func asStringOrJson(data map[string]interface{}, prop string) (string, error) {
 	if !ok {
 		return "", errors.New(fmt.Sprintf("property %s is not found", prop))
 	}
-	switch v := expr.(type) {
+	switch v := expr.(type) { // TODO: Use json.Valid() instead
 	case string:
 		return v, nil
 	default:

--- a/regoservice/eval.go
+++ b/regoservice/eval.go
@@ -1,6 +1,7 @@
 package regoservice
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -113,7 +114,13 @@ func asStringOrJson(data map[string]interface{}, prop string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return string(val), nil
+
+		var out bytes.Buffer
+		if err = json.Compact(&out, val); err != nil { // Remove extra '\n' et al.
+			return "", err
+		}
+
+		return out.String(), nil
 	}
 }
 func (regoEvaluator *regoEvaluator) BuildAggregatedContent(scans []map[string]string) (map[string]string, error) {


### PR DESCRIPTION
This PR adds the support for the following:

```
- name: my-k8s
  type: kubernetes
  enable: true
  kube-namespace: "default"                         # Required. Kubernetes namespace to use.
  kube-config-file: "/path/to/kubeconfig"           # Required. Path to .kubeconfig file
  kube-label-selector: "app=nginx-app"              # Required, if specifying labels or annotations.
  kube-actions:
    labels:
      foo-label: "bar-value"                        # Required. Label to add.
      bar-label: event.input.SigMetadata.ID         # Optional. It is also possible to add labels based on event inputs.
    annotations:
      foo-annotation: "bar-value"
      bar-annotation: event.input.SigMetadata.ID
```

Signed-off-by: Simar <simar@linux.com>