### PR TITLE
feat(actions): Make k8s action k8s aware

### DIFF
--- a/cfg-k8s-actions.yaml
+++ b/cfg-k8s-actions.yaml
@@ -33,7 +33,7 @@ outputs:
   type: kubernetes
   enable: true
   kube-namespace: "default"                         # Required. Kubernetes namespace to use.
-  kube-config-file: "/path/to/kubeconfig"           # Required. Path to .kubeconfig file
+  kube-config-file: "/path/to/kubeconfig"           # Required if not running on K8S, Optional otherwise.
   kube-label-selector: "app=nginx-app"              # Required, if specifying labels or annotations.
   kube-actions:
     labels:

--- a/outputs/kubernetes.go
+++ b/outputs/kubernetes.go
@@ -78,7 +78,11 @@ func (k KubernetesClient) prepareInputs(input map[string]string) map[string]map[
 			} else {
 				calcVal = val // no rego to parse
 			}
-			a[key] = map[string]string{id: calcVal}
+			if _, ok := a[key][id]; !ok && len(a[key]) <= 0 {
+				a[key] = map[string]string{id: calcVal}
+			} else {
+				a[key][id] = calcVal
+			}
 		}
 	}
 

--- a/outputs/kubernetes_test.go
+++ b/outputs/kubernetes_test.go
@@ -37,13 +37,17 @@ func TestKubernetesClient_Send(t *testing.T) {
 			},
 			{
 				name:       "happy path, json input event, relative input labels are added",
-				inputEvent: `{"SigMetadata":{"ID":"TRC-2"}}`,
+				inputEvent: `{"SigMetadata":{"ID":"TRC-2", "Hostname":"foo.com"}}`,
 				inputActions: map[string]map[string]string{
-					"labels": {"foo": "event.input.SigMetadata.ID"},
+					"labels": {
+						"foo":      "event.input.SigMetadata.ID",
+						"hostname": "event.input.SigMetadata.Hostname",
+					},
 				},
 				expectedLabels: map[string]string{
-					"app": "nginx",
-					"foo": "TRC-2",
+					"app":      "nginx",
+					"foo":      "TRC-2",
+					"hostname": "foo.com",
 				},
 			},
 			{

--- a/router/builders.go
+++ b/router/builders.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -170,8 +171,10 @@ func buildHTTPOutput(sourceSettings *OutputSettings) (*outputs.HTTPClient, error
 }
 
 func buildKubernetesOutput(sourceSettings *OutputSettings) (*outputs.KubernetesClient, error) {
-	if sourceSettings.KubeConfigFile == "" {
-		return nil, fmt.Errorf("kubernetes config file needs to be set in config yaml")
+	if !IsK8s() {
+		if sourceSettings.KubeConfigFile == "" {
+			return nil, fmt.Errorf("kubernetes config file needs to be set in config yaml")
+		}
 	}
 
 	if sourceSettings.KubeNamespace == "" {
@@ -185,6 +188,11 @@ func buildKubernetesOutput(sourceSettings *OutputSettings) (*outputs.KubernetesC
 		KubeLabelSelector: sourceSettings.KubeLabelSelector,
 		KubeActions:       sourceSettings.KubeActions,
 	}, nil
+}
+
+func IsK8s() bool {
+	_, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST")
+	return ok
 }
 
 func buildDockerOutput(sourceSettings *OutputSettings) (*outputs.DockerClient, error) {


### PR DESCRIPTION
This PR does the following:

1. Fixes a bug when multiple labels are specified.
2 Makes .kube/config optional if running with k8s.


Signed-off-by: Simar <simar@linux.com> 