### PR TITLE
fix(github): Use full path to k8s yaml.

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -38,7 +38,7 @@ jobs:
           image: ${{ env.KIND_IMAGE }}
       - name: Installing Kubernetes Postee manifest
         run: |
-            kubectl create -f deploy/kubernetes
+            kubectl create -f deploy/kubernetes/postee.yaml
       - name: Testing Kubernetes Postee manifest
         run: |
             kubectl wait --for=condition=Ready pod -l app=postee --timeout=150s


### PR DESCRIPTION
Since we have postee-actions.yaml now within the deploy directory, we should be specific about the YAML we use to create.

Fixes:
<img width="758" alt="image" src="https://user-images.githubusercontent.com/1254783/160944850-46e21205-e475-4fa4-b7b4-b81af1131e96.png">


Signed-off-by: Simar <simar@linux.com>