### PR TITLE
chore: gh publish helm manually using the release

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -1,3 +1,4 @@
+# Triggered manually using as input the release e.g. v0.0.1
 name: Publish Chart Helm
 on:
   pull_request:
@@ -7,32 +8,26 @@ on:
       - 'deploy/helm/**'
       - 'deploy/kubernetes/**'
   push:
-    branches: [main]
-    paths:
-      - 'deploy/helm/**'
-      - 'deploy/kubernetes/**'
     tags:
       - "v*"
-  workflow_dispatch:
+  workflow_dispatch: # manually it will get the latest tag to publish the helm chart
 env:
   HELM_REP: helm-charts
   GH_OWNER: aquasecurity
   CHART_DIR: deploy/helm/postee
   GO_VERSION: "1.18"
-  KIND_VERSION: "v0.11.1"
-  KIND_IMAGE: "kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c"
+  KIND_VERSION: "v0.12.0"
+  KIND_IMAGE: "kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9"
 jobs:
-  publish:
+  test-chart:
     runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 #v2.4.0
+        uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
         with:
           fetch-depth: 0
       - name: Setup Kubernetes cluster (KIND)
-        uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478 #v1.2.0
+        uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478
         with:
           version: ${{ env.KIND_VERSION }}
           image: ${{ env.KIND_IMAGE }}
@@ -50,9 +45,24 @@ jobs:
       - name: Testing Helm Postee manifest
         run: |
             helm upgrade --install test deploy/helm/postee --debug
+
+  publish-chart:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs:
+      - test-chart
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
+        with:
+          fetch-depth: 0
+      - name: Install Helm
+        uses: azure/setup-helm@v2.1
+        with:
+          version: v3.6.0
       - name: Install chart-releaser
         env:
-          VERSION: 1.2.1
+          VERSION: 1.3.0
         run: |
           wget "https://github.com/helm/chart-releaser/releases/download/v${VERSION}/chart-releaser_${VERSION}_linux_amd64.tar.gz"
           tar xzvf chart-releaser_${VERSION}_linux_amd64.tar.gz cr
@@ -80,7 +90,7 @@ jobs:
         continue-on-error: true
         ## Upload the tar in the Releases repository
         run: |
-          ./cr upload -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} --token ${{ secrets.ORG_REPO_TOKEN }}
+          ./cr upload -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} --token ${{ secrets.ORG_REPO_TOKEN }} -p .cr-release-packages
       - name: Index helm chart
         run: |
           ./cr index -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} -c https://${{ env.GH_OWNER }}.github.io/${{ env.HELM_REP }}/ -i index.yaml


### PR DESCRIPTION
- Removing the publish helm chart when pushed to the main branch.
- publish the helm chart only with the release tag 
- @simar7 we are using the same app version to the chart app, we use the latest tag publish. https://github.com/aquasecurity/postee/blob/main/.github/workflows/publish-chart.yml#L77