### PR TITLE
chore: use the image tag of the release in the helm chart

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,9 @@ builds:
       - arm64
     goarm:
       - 7
+    ignore:
+      - goos: darwin
+        goarch: 386      
 archives:
   - name_template: "{{ .ProjectName }}_{{.Version}}_{{ .Os }}_{{ .Arch }}"
     builds:
@@ -98,3 +101,23 @@ dockers:
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/postee/v{{ .Version }}/"
       - "--platform=linux/amd64"
+docker_manifests:
+  - name_template: 'aquasec/postee:{{ .Version }}'
+    image_templates:
+    - 'aquasec/postee:{{ .Version }}-amd64'
+  - name_template: 'public.ecr.aws/aquasecurity/postee:{{ .Version }}'
+    image_templates:
+    - 'public.ecr.aws/aquasecurity/postee:{{ .Version }}-amd64'
+  - name_template: 'aquasec/postee:latest'
+    image_templates:
+    - 'aquasec/postee:{{ .Version }}-amd64'
+# Postee-UI
+  - name_template: 'aquasec/postee-ui:{{ .Version }}'
+    image_templates:
+    - 'aquasec/postee-ui:{{ .Version }}-amd64'
+  - name_template: 'public.ecr.aws/aquasecurity/postee-ui:{{ .Version }}'
+    image_templates:
+    - 'public.ecr.aws/aquasecurity/postee-ui:{{ .Version }}-amd64'
+  - name_template: 'aquasec/postee-ui:latest'
+    image_templates:
+    - 'aquasec/postee-ui:{{ .Version }}-amd64'

--- a/deploy/helm/postee/values.yaml
+++ b/deploy/helm/postee/values.yaml
@@ -10,13 +10,13 @@ posteUi:
   user: ""
   pass: ""
   image: aquasec/postee-ui
-  tag: "latest"
+  tag: ""
 
 image:
   repository: aquasec/postee
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: ""
 imageInit:
   repository: busybox
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Currently the helm chart is using the latest tag. This PR will fix it and use the latest image release postee `docker pull aquasec/postee:0.24.0`

```
 k -n postee get statefulsets.apps -o wide
NAME         READY   AGE   CONTAINERS   IMAGES
app-postee   1/1     23m   postee       aquasec/postee:latest

 k -n postee get deployments.apps -o wide
NAME           READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                     SELECTOR
app-posteeui   1/1     1            1           23m   postee       aquasec/postee-ui:latest   app.kubernetes.io/instance=app,app.kubernetes.io/name=postee-ui
```