### PR TITLE
[fix] helm chart name in docs (aquasecurity->aqua)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -92,7 +92,7 @@ Let's add the Helm chart and deploy Postee executing:
 helm repo add aquasecurity https://aquasecurity.github.io/helm-charts/
 helm repo update
 helm search repo postee
-helm install app --create-namespace -n postee aquasecurity/postee
+helm install app --create-namespace -n postee aqua/postee
 ```
 
 Check that all the pods are in Running state:


### PR DESCRIPTION
postee's helm chart name has been changed.
This is fixing a trivial documentation issue.

Sorry, but I could not figure out how to officially commit. Please close if there is a problem.
