### PR TITLE
[fix] make ingress compatible with k8s 1.22+

### DIFF
--- a/deploy/helm/postee/templates/ingress.yaml
+++ b/deploy/helm/postee/templates/ingress.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "postee.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
 {{- else -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 {{- end }}
 kind: Ingress
 metadata:

--- a/deploy/helm/postee/templates/postee-ui.yaml
+++ b/deploy/helm/postee/templates/postee-ui.yaml
@@ -64,19 +64,20 @@ spec:
               containerPort: {{ .Values.posteUi.port }}
               protocol: TCP
           volumeMounts:
-            - name: postee-config
+          {{- if .Values.persistentVolume.enabled }}        
+            - name: {{ $fullName }}-data
               mountPath: {{ .Values.persistentVolume.mountPathConfig }}
-            - name: postee-db
+            - name: {{ $fullName }}-data
               mountPath: {{ .Values.persistentVolume.mountPathDb }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
-        - name: postee-db
+        {{- if .Values.persistentVolume.enabled }}
+        - name: {{ $fullName }}-data
           persistentVolumeClaim:
-            claimName: "{{ $fullName }}-db-{{ $fullName }}-0"
-        - name: postee-config
-          persistentVolumeClaim:
-            claimName: "{{ $fullName }}-config-{{ $fullName }}-0"
+            claimName: {{ $fullName }}-pvc      
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/postee/templates/postee-ui.yaml
+++ b/deploy/helm/postee/templates/postee-ui.yaml
@@ -34,8 +34,10 @@ spec:
           imagePullPolicy: {{ .Values.imageInit.pullPolicy }}
           command: ["/bin/chown", "-R", "1099", "{{ .Values.persistentVolume.mountPathConfig }}"]
           volumeMounts:
-            - name: postee-config
+          {{- if .Values.persistentVolume.enabled }}        
+            - name: {{ $fullName }}-data
               mountPath: {{ .Values.persistentVolume.mountPathConfig }}
+          {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/deploy/helm/postee/templates/postee.yaml
+++ b/deploy/helm/postee/templates/postee.yaml
@@ -13,35 +13,6 @@ spec:
     matchLabels:
       {{- include "postee.selectorLabels" . | nindent 6 }}
   serviceName: {{ include "postee.fullname" . }}
-  volumeClaimTemplates:
-    - metadata:
-        name: {{ $fullName }}-db
-      spec:
-        accessModes: [ "ReadWriteOnce" ]
-        resources:
-          requests:
-            storage: 1Gi
-    - metadata:
-        name: {{ $fullName }}-config
-      spec:
-        accessModes: [ "ReadWriteOnce" ]
-        resources:
-          requests:
-            storage: 100Mi
-    - metadata:
-        name: {{ $fullName }}-rego-template
-      spec:
-        accessModes: [ "ReadWriteOnce" ]
-        resources:
-          requests:
-            storage: 100Mi
-    - metadata:
-        name: {{ $fullName }}-filters
-      spec:
-        accessModes: [ "ReadWriteOnce" ]
-        resources:
-          requests:
-            storage: 100Mi
   template:
     metadata:
       annotations:
@@ -65,8 +36,10 @@ spec:
           imagePullPolicy: {{ .Values.imageInit.pullPolicy }}
           command: ["/bin/chown", "-R", "1099", "{{ .Values.persistentVolume.mountPathDb }}"]
           volumeMounts:
-            - name: {{ $fullName }}-db
+          {{- if .Values.persistentVolume.enabled }}
+            - name: {{ $fullName }}-data
               mountPath: {{ .Values.persistentVolume.mountPathDb }}
+          {{- end }}
         - name: setting-cfg
           image: "{{ .Values.imageInit.repository }}:{{ .Values.imageInit.tag }}"
           imagePullPolicy: {{ .Values.imageInit.pullPolicy }}
@@ -74,8 +47,10 @@ spec:
           volumeMounts:
             - name: {{ $fullName }}-configmap-vol
               mountPath: /k8s
-            - name: {{ $fullName }}-config
+          {{- if .Values.persistentVolume.enabled }}
+            - name: {{ $fullName }}-data
               mountPath: {{ .Values.persistentVolume.mountPathConfig }}
+          {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -95,20 +70,27 @@ spec:
               containerPort: {{ .Values.service.targetPortSsl }}
               protocol: TCP
           volumeMounts:
-            - name: {{ $fullName }}-db
+          {{- if .Values.persistentVolume.enabled }}        
+            - name: {{ $fullName }}-data
               mountPath: {{ .Values.persistentVolume.mountPathDb }}
-            - name: {{ $fullName }}-config
+            - name: {{ $fullName }}-data
               mountPath: {{ .Values.persistentVolume.mountPathConfig }}
-            - name: {{ $fullName }}-rego-template
+            - name: {{ $fullName }}-data
               mountPath: {{ .Values.persistentVolume.mountPathRego }}
-            - name: {{ $fullName }}-filters
+            - name: {{ $fullName }}-data
               mountPath: {{ .Values.persistentVolume.mountPathFilters }}
+          {{- end }}                
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - configMap:
             name: {{ $fullName }}-cfg
           name: {{ $fullName }}-configmap-vol
+        {{- if .Values.persistentVolume.enabled }}
+        - name: {{ $fullName }}-data
+          persistentVolumeClaim:
+            claimName: {{ $fullName }}-pvc      
+        {{- end }}             
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/postee/values.yaml
+++ b/deploy/helm/postee/values.yaml
@@ -258,7 +258,7 @@ affinity: {}
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
 persistentVolume:
-  enabled: false
+  enabled: true
   mountPathDb: /server/database
   mountPathConfig: /data
   mountPathRego: /server/rego-templates/custom


### PR DESCRIPTION
Issue:
https://github.com/aquasecurity/postee/issues/477

Changing the apiVersion on Ingress template to use buildIn .Capabilities.KubeVersion.GitVersion >= 1.19  to solve the issue.

After the change the Ingress is properly validated and installed on 1.22+ clusters:

> Source: postee/templates/ingress.yaml
> apiVersion: networking.k8s.io/v1
> kind: Ingress
> metadata:
>   name: postee
>   labels:
>     helm.sh/chart: postee-0.4.4
>     app.kubernetes.io/name: postee
>     app.kubernetes.io/instance: postee
>     app.kubernetes.io/version: "2.8.4-amd64"
>     app.kubernetes.io/managed-by: Helm
>   annotations:
>     kubernetes.io/ingress.class: nginx
> spec:
>   tls:
>     - hosts:
>         - "postee-jx3.develop.xxxxxxx.systems"
>       secretName: tls-develop-xxxxxx-systems-p
>   rules:
>     - host: "postee-jx3.develop.xxxxxxx.systems"
>       http:
>         paths:
>           - path: /
>             backend:
>               serviceName: postee
>               servicePort: 8082