### PR TITLE
feat(Helm): Provide sensitive values as secret

### DIFF
--- a/deploy/helm/postee/templates/cfg-configmap.yaml
+++ b/deploy/helm/postee/templates/cfg-configmap.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "postee.fullname" . }}-cfg
-data:
-  cfg.yaml: |
-{{ .Values.posteeConfig  | indent 4 }}

--- a/deploy/helm/postee/templates/cfg-secret.yaml
+++ b/deploy/helm/postee/templates/cfg-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "postee.fullname" . }}-secret
+data:
+  cfg.yaml: |
+{{ .Values.posteeConfig  | b64enc | indent 4 }}

--- a/deploy/helm/postee/templates/postee.yaml
+++ b/deploy/helm/postee/templates/postee.yaml
@@ -45,7 +45,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/cfg-configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/cfg-secret.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -72,7 +72,7 @@ spec:
           imagePullPolicy: {{ .Values.imageInit.pullPolicy }}
           command: ["/bin/cp", "/k8s/cfg.yaml", "/data/cfg.yaml"]
           volumeMounts:
-            - name: {{ $fullName }}-configmap-vol
+            - name: {{ $fullName }}-secret-vol
               mountPath: /k8s
             - name: {{ $fullName }}-config
               mountPath: {{ .Values.persistentVolume.mountPathConfig }}
@@ -106,9 +106,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
-        - configMap:
-            name: {{ $fullName }}-cfg
-          name: {{ $fullName }}-configmap-vol
+        - secret:
+            secretName: {{ $fullName }}-secret
+          name: {{ $fullName }}-secret-vol
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Related to #479

A little bit of a lazy implementation but this way we could simply overwrite the whole content of the config file as a secret provided from another source (Hashicorp Vault + External Secrets Operator in our case)

Open for feedback of course but I am going to be on vacation for two weeks now.

Cheers!