### PR TITLE
fea(slack): add skip tls verification

### DIFF
--- a/actions/slack.go
+++ b/actions/slack.go
@@ -22,6 +22,7 @@ type SlackAction struct {
 	Name        string
 	AquaServer  string
 	Url         string
+	TlsVerify   bool
 	slackLayout layout.LayoutProvider
 }
 

--- a/cfg.yaml
+++ b/cfg.yaml
@@ -105,6 +105,7 @@ actions:
   type: slack
   enable: false
   url: https://hooks.slack.com/services/TAAAA/BBB/<key>
+  tls-verify: false # Enable skip TLS Verification. Default: false.
 
 - name: ms-team
   type: teams

--- a/deploy/helm/postee/values.yaml
+++ b/deploy/helm/postee/values.yaml
@@ -114,6 +114,7 @@ posteeConfig: |
     type: slack
     enable: false
     url: https://hooks.slack.com/services/TAAAA/BBB/<key>
+    tls-verify: false # Enable skip TLS Verification. Default: false.
 
   - name: ms-team
     type: teams

--- a/deploy/kubernetes/postee.yaml
+++ b/deploy/kubernetes/postee.yaml
@@ -31,6 +31,7 @@ data:
         enable: false
         url: >-
           https://hooks.slack.com/services/xxxxxxx/xxxxxxx/xxxxxxx
+        tls-verify: false # Enable skip TLS Verification. Default: false.
       - type: teams
         name: my-teams
         enable: false

--- a/router/builders.go
+++ b/router/builders.go
@@ -58,6 +58,7 @@ func buildSlackAction(sourceSettings *ActionSettings, aqua string) *actions.Slac
 		Name:       sourceSettings.Name,
 		AquaServer: aqua,
 		Url:        sourceSettings.Url,
+		TlsVerify:  sourceSettings.TlsVerify,
 	}
 }
 

--- a/slack/sendtoslack.go
+++ b/slack/sendtoslack.go
@@ -2,6 +2,7 @@ package slack_api
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -9,8 +10,12 @@ import (
 )
 
 func SendToUrl(url string, data []byte) error {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
 	r := bytes.NewReader(data)
-	resp, err := http.Post(url, "application/json", r)
+	resp, err := client.Post(url, "application/json", r)
 	if err != nil {
 		log.Printf("Slack API error: %v", err)
 		return err


### PR DESCRIPTION
## Description
Add skip tls verification for Slack.
Use `tls-verify` for this.

## Related Issue
- #496 