### PR TITLE
feat(splunk): add skip tls verification

### DIFF
--- a/cfg.yaml
+++ b/cfg.yaml
@@ -123,6 +123,7 @@ actions:
   url: http://localhost:8088 # Mandatory. Url of a Splunk server
   token: <token>             # Mandatory. a HTTP Event Collector Token
   size-limit: 10000          # Optional. Maximum scan length, in bytes. Default: 10000
+  tls-verify: false          # Enable skip TLS Verification. Default: false.
 
 - name: my-servicenow
   type: serviceNow

--- a/deploy/helm/postee/values.yaml
+++ b/deploy/helm/postee/values.yaml
@@ -132,6 +132,7 @@ posteeConfig: |
     url: http://localhost:8088 # Mandatory. Url of a Splunk server
     token: <token>             # Mandatory. a HTTP Event Collector Token
     size-limit: 10000          # Optional. Maximum scan length, in bytes. Default: 10000
+    tls-verify: false          # Enable skip TLS Verification. Default: false.
 
   - name: my-servicenow
     type: serviceNow

--- a/router/builders.go
+++ b/router/builders.go
@@ -20,6 +20,7 @@ func buildSplunkAction(sourceSettings *ActionSettings) *actions.SplunkAction {
 		Url:        sourceSettings.Url,
 		Token:      sourceSettings.Token,
 		EventLimit: sourceSettings.SizeLimit,
+		TlsVerify:  sourceSettings.TlsVerify,
 	}
 }
 


### PR DESCRIPTION
## Description
Add skip tls verification for `Splunk`.
Use `tls-verify` for this.

## Related Issue
- #496 