### PR TITLE
Feat(helm): environment variables from secret

### DIFF
--- a/deploy/helm/postee/templates/postee.yaml
+++ b/deploy/helm/postee/templates/postee.yaml
@@ -87,6 +87,13 @@ spec:
               value: /data/cfg.yaml
             - name: POSTEE_DEBUG
               value: "not"
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- range . }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.targetPort }}

--- a/deploy/helm/postee/values.yaml
+++ b/deploy/helm/postee/values.yaml
@@ -280,5 +280,5 @@ persistentVolume:
 
 ## Secrets as environment variables
 ## If defined, these secrets are mounted as environment variables
-envFrom:
-  - my-env-secret-1
+## envFrom:
+##   - my-env-secret-1

--- a/deploy/helm/postee/values.yaml
+++ b/deploy/helm/postee/values.yaml
@@ -277,3 +277,8 @@ persistentVolume:
   ##
   # storageClass: "-"
   # existingClaim: ""
+
+## Secrets as environment variables
+## If defined, these secrets are mounted as environment variables
+envFrom:
+  - my-env-secret-1

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -13,6 +13,27 @@ actions:
   token: $JIRA_SERVER_TOKEN         
 ```
 
+### Helm
+
+When installing Postee on Kubernetes with Helm, you can provide environment variables from Kubernetes secrets.
+Given there is a Secret containing sensitive information:
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque
+data:
+  JIRA_USERNAME: secret-username
+  JIRA_SERVER_TOKEN: secret-token
+```
+
+You can refer to this secret and use its data in Postee by specifying its name in the Helm values:
+```
+envFrom:
+  - mysecret
+```
+
 ## Customizing Templates
 Postee loads bundle of templates from `rego-templates` folder. This folder includes several templates shipped with Postee, which can be used out of the box. You can add additional custom templates by placing Rego file under the 'rego-templates' directory.
 


### PR DESCRIPTION
This changes enables kubernetes secrets to be used as source for environment variables.

Environment variables can be used in the config file, as documented [here](https://aquasecurity.github.io/postee/advanced/#using-environment-variables-in-postee-configuration-file). However it was not possible to set this up with the helm chart.

With this change it is possible to define any secrets to be mounted into the container:
```
envFrom:
  - my-env-secret-1
  - my-env-secret-2
  - ...
```