### PR TITLE
feat: add is_new field iac templates

### DIFF
--- a/rego-templates/common/common.rego
+++ b/rego-templates/common/common.rego
@@ -85,7 +85,8 @@ get_numbers_of_new_vulns(vuln_type, severity) = n{
 number_of_vulns(vuln_type, severity) = str{
     new = get_numbers_of_new_vulns(vuln_type, severity)
     new == 0
-    str := sprintf("%d",[new])
+    all_vulns = with_default(input,sprintf("%s_%s_count", [vuln_type, lower(severity_as_string(severity))]), 0)
+    str := sprintf("%d",[all_vulns])
 }
 
 number_of_vulns(vuln_type, severity) = str{

--- a/rego-templates/common/common.rego
+++ b/rego-templates/common/common.rego
@@ -32,6 +32,8 @@ with_default(obj, prop, default_value) = obj[prop]{
  obj[prop]
 }
 
+
+## functions for IAC:
 severity_as_string(severity) := "Critical" if {
     severity == 4
 } else = "High" if {
@@ -41,3 +43,54 @@ severity_as_string(severity) := "Critical" if {
 } else = "Low" if {
     severity == 1
 } else = "Unknown"
+
+
+is_misconfig(vuln_type) = true if {
+	vuln_type != 0; vuln_type != 7; vuln_type != 8; vuln_type != 10; vuln_type != 11
+} else = false
+
+get_numbers_of_new_vulns(vuln_type, severity) = n{
+    vuln_type == "vulnerability"
+	results := [r |
+    			r := input.results[_]
+                r.is_new
+                r.type == 7
+                r.severity == severity
+                ]
+    n := count(results)
+}
+
+get_numbers_of_new_vulns(vuln_type, severity) = n{
+    vuln_type == "pipeline_misconfiguration"
+	results := [r |
+    			r := input.results[_]
+                r.is_new
+                r.type == 10
+                r.severity == severity
+                ]
+    n := count(results)
+}
+
+get_numbers_of_new_vulns(vuln_type, severity) = n{
+    vuln_type == "misconfiguration"
+	results := [r |
+    			r := input.results[_]
+                r.is_new
+                is_misconfig(r.type)
+                r.severity == severity
+                ]
+    n := count(results)
+}
+
+number_of_vulns(vuln_type, severity) = str{
+    new = get_numbers_of_new_vulns(vuln_type, severity)
+    new == 0
+    str := sprintf("%d",[new])
+}
+
+number_of_vulns(vuln_type, severity) = str{
+    new = get_numbers_of_new_vulns(vuln_type, severity)
+    new != 0
+    all_vulns = with_default(input,sprintf("%s_%s_count", [vuln_type, lower(severity_as_string(severity))]), 0)
+    str := sprintf("%d (%d new)", [all_vulns, new])
+}

--- a/rego-templates/iac-html.rego
+++ b/rego-templates/iac-html.rego
@@ -95,7 +95,7 @@ severities_stats(vuln_type) = stats{
       ]
 }
 
-vlnrb_headers := ["ID", "Severity"]
+vlnrb_headers := ["ID", "Severity", "New"]
 
 vln_list = vlnrb {
 	some i
@@ -103,8 +103,9 @@ vln_list = vlnrb {
     				result := input.results[i]
     				avd_id := result.avd_id
                     severity := severity_as_string(result.severity)
+                    is_new := with_default(result, "is_new", false)
 
-                    r := [avd_id, severity]
+                    r := [avd_id, severity, is_new]
               ]
 }
 

--- a/rego-templates/iac-html.rego
+++ b/rego-templates/iac-html.rego
@@ -1,9 +1,9 @@
 package postee.iac.html
 
+import future.keywords.if
 import data.postee.with_default
 import data.postee.severity_as_string
-
-
+import data.postee.number_of_vulns
 ################################################ Templates ################################################
 tpl:=`
 <p><b>Triggered by:</b> %s</p>
@@ -82,16 +82,16 @@ to_colored_text(color, txt) = spn {
 
 ####################################### Template specific functions #######################################
 to_severity_color(color, level) = spn {
- spn:=to_colored_text(color, format_int(with_default(input,level,0), 10))
+ spn:=to_colored_text(color, level)
 }
 
 severities_stats(vuln_type) = stats{
     stats := [
-          ["critical", to_severity_color("#c00000", sprintf("%s_critical_count", [vuln_type]))],
-          ["high", to_severity_color("#e0443d", sprintf("%s_high_count", [vuln_type]))],
-          ["medium", to_severity_color("#f79421", sprintf("%s_medium_count", [vuln_type]))],
-          ["low", to_severity_color("#e1c930", sprintf("%s_low_count", [vuln_type]))],
-          ["unknown", to_severity_color("green", sprintf("%s_unknown_count", [vuln_type]))]
+          ["critical", to_severity_color("#c00000", number_of_vulns(vuln_type, 4))],
+          ["high", to_severity_color("#e0443d", number_of_vulns(vuln_type, 3))],
+          ["medium", to_severity_color("#f79421", number_of_vulns(vuln_type, 2))],
+          ["low", to_severity_color("#e1c930", number_of_vulns(vuln_type, 1))],
+          ["unknown", to_severity_color("green", number_of_vulns(vuln_type, 0))]
       ]
 }
 

--- a/rego-templates/iac-jira.rego
+++ b/rego-templates/iac-jira.rego
@@ -36,8 +36,9 @@ vln_list = vlnrb {
     				result := input.results[i]
     				avd_id := result.avd_id
                     severity := severity_as_string(result.severity)
+                    is_new := with_default(result, "is_new", false)
 
-                    r := sprintf("|%s|%s|\n",[avd_id, severity])
+                    r := sprintf("|%s|%s|%s|\n",[avd_id, severity, is_new])
               ]
 }
 
@@ -50,7 +51,7 @@ concat_list(prefix,list) = output{
 vln_list_table = table {
                 list := vln_list
                 count(list) > 0
-                prefix := ["\n*List of CVEs:*\n||*ID*                    ||*Severity*                   ||\n"]
+                prefix := ["\n*List of CVEs:*\n||*ID*                    ||*Severity*                   ||*New*                   ||\n"]
                 table := concat_list(prefix,list)
 }
 

--- a/rego-templates/iac-jira.rego
+++ b/rego-templates/iac-jira.rego
@@ -2,6 +2,7 @@ package postee.iac.jira
 
 import data.postee.with_default
 import data.postee.severity_as_string
+import data.postee.number_of_vulns
 import future.keywords.if
 
 ################################################ Templates ################################################
@@ -22,13 +23,13 @@ tpl:=`
 `
 
 ####################################### Template specific functions #######################################
-severities_stats_table(vuln_type) = sprintf("\n*%s summary:*\n||*Severity*                        ||*Score*                       ||\n|Critical|%v|\n|High|%v|\n|Meduim|%v|\n|Low|%v|\n|Unknown|%v|\n", [
+severities_stats_table(vuln_type) = sprintf("\n*%s summary:*\n||*Severity*                        ||*Score*                       ||\n|Critical|%s|\n|High|%s|\n|Meduim|%s|\n|Low|%s|\n|Unknown|%s|\n", [
                                     vuln_type,
-                                    format_int(with_default(input,sprintf("%s_critical_count", [lower(replace(vuln_type, " ", "_"))]),0), 10),
-                                    format_int(with_default(input,sprintf("%s_high_count", [lower(replace(vuln_type, " ", "_"))]),0), 10),
-                                    format_int(with_default(input,sprintf("%s_medium_count", [lower(replace(vuln_type, " ", "_"))]),0), 10),
-                                    format_int(with_default(input,sprintf("%s_low_count", [lower(replace(vuln_type, " ", "_"))]),0), 10),
-                                    format_int(with_default(input,sprintf("%s_unknown_count", [lower(replace(vuln_type, " ", "_"))]),0), 10)])
+                                    number_of_vulns(lower(replace(vuln_type, " ", "_")), 4),
+                                    number_of_vulns(lower(replace(vuln_type, " ", "_")), 3),
+                                    number_of_vulns(lower(replace(vuln_type, " ", "_")), 2),
+                                    number_of_vulns(lower(replace(vuln_type, " ", "_")), 1),
+                                    number_of_vulns(lower(replace(vuln_type, " ", "_")), 0)])
 
 vln_list = vlnrb {
 	some i

--- a/rego-templates/iac-servicenow.rego
+++ b/rego-templates/iac-servicenow.rego
@@ -101,7 +101,7 @@ severities_stats(vuln_type) = stats{
       ]
 }
 
-vlnrb_headers := ["ID", "Severity"]
+vlnrb_headers := ["ID", "Severity", "New"]
 
 vln_list = vlnrb {
 	some i
@@ -109,8 +109,9 @@ vln_list = vlnrb {
     				result := input.results[i]
     				avd_id := result.avd_id
                     severity := severity_as_string(result.severity)
+                    is_new := with_default(result, "is_new", false)
 
-                    r := [avd_id, severity]
+                    r := [avd_id, severity, is_new]
               ]
 }
 

--- a/rego-templates/iac-servicenow.rego
+++ b/rego-templates/iac-servicenow.rego
@@ -3,6 +3,7 @@ package postee.iac.servicenow
 import data.postee.by_flag
 import data.postee.with_default
 import data.postee.severity_as_string
+import data.postee.number_of_vulns
 import future.keywords
 import future.keywords.if
 
@@ -88,16 +89,16 @@ to_colored_text(color, txt) = spn {
 
 ####################################### Template specific functions #######################################
 to_severity_color(color, level) = spn {
- spn:=to_colored_text(color, format_int(with_default(input,level,0), 10))
+ spn:=to_colored_text(color, level)
 }
 
 severities_stats(vuln_type) = stats{
     stats := [
-          ["critical", to_severity_color("#c00000", sprintf("%s_critical_count", [vuln_type]))],
-          ["high", to_severity_color("#e0443d", sprintf("%s_high_count", [vuln_type]))],
-          ["medium", to_severity_color("#f79421", sprintf("%s_medium_count", [vuln_type]))],
-          ["low", to_severity_color("#e1c930", sprintf("%s_low_count", [vuln_type]))],
-          ["unknown", to_severity_color("green", sprintf("%s_unknown_count", [vuln_type]))]
+          ["critical", to_severity_color("#c00000", number_of_vulns(vuln_type, 4))],
+          ["high", to_severity_color("#e0443d", number_of_vulns(vuln_type, 3))],
+          ["medium", to_severity_color("#f79421", number_of_vulns(vuln_type, 2))],
+          ["low", to_severity_color("#e1c930", number_of_vulns(vuln_type, 1))],
+          ["unknown", to_severity_color("green", number_of_vulns(vuln_type, 0))]
       ]
 }
 

--- a/rego-templates/iac-slack.rego
+++ b/rego-templates/iac-slack.rego
@@ -56,10 +56,11 @@ vln_list = l {
                     result := input.results[i]
     				avd_id := result.avd_id
                     severity := severity_as_string(result.severity)
+                    is_new := with_default(result, "is_new", false)
 
                     r := [
                     	{"type": "mrkdwn", "text": avd_id},
-                    	{"type": "mrkdwn", "text": severity}
+                    	{"type": "mrkdwn", "text": sprintf("%s/%s", [severity, is_new])},
                     ]
 
               ]
@@ -67,7 +68,7 @@ vln_list = l {
 
     headers := [
         {"type": "mrkdwn", "text": "*ID*"},
-        {"type": "mrkdwn", "text": "*Severity*"}
+        {"type": "mrkdwn", "text": "*Severity / New*"}
     ]
     rows := array.concat(headers, flat_array(vlnrb))
 

--- a/rego-templates/iac-slack.rego
+++ b/rego-templates/iac-slack.rego
@@ -4,17 +4,17 @@ import data.postee.flat_array #converts [[{...},{...}], [{...},{...}]] to [{...}
 import data.postee.with_default
 import data.postee.severity_as_string
 import future.keywords.if
-
+import data.postee.number_of_vulns
 
 ####################################### Template specific functions #######################################
 
-severities := ["critical", "high", "medium", "low", "unknown"]
+severities := [4, 3, 2, 1, 0]
 
 severity_stats(vuln_type) := flat_array([gr |
 	severity := severities[_]
 	gr := [
-		{"type": "mrkdwn", "text": sprintf("%s", [severity])},
-		{"type": "mrkdwn", "text": sprintf("%d", [with_default(input, sprintf("%s_%s_count", [vuln_type, severity]), 0)])},
+		{"type": "mrkdwn", "text": sprintf("%s", [severity_as_string(severity)])},
+		{"type": "mrkdwn", "text": number_of_vulns(vuln_type, severity)},
 	]
 ])
 


### PR DESCRIPTION
## Description
- add `is_new` field in CVE tables:
![image](https://user-images.githubusercontent.com/91113035/217505357-5968a40d-dc67-44bf-99a5-dbfb70c752c1.png)

- add `(x new)` in summary tables.
![image](https://user-images.githubusercontent.com/91113035/217505307-4eaa17c8-9c58-47e7-90c3-ce3e0a366289.png)
