### PR TITLE
fix: update the image for Node builder

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,4 +1,4 @@
-FROM node:alpine3.15 as vuebuilder
+FROM node:18-alpine3.17 as vuebuilder
 COPY ./ui/frontend /frontend
 WORKDIR /frontend
 


### PR DESCRIPTION
Postee UI contains a dependency that wasn't updated yet and doesn't support the latest Node version (19).

I've changed the image for Node builder to Node 18.

Node 18 has Long Term Support (maintenance end is 2025-04-30), so I think it's ok.

- close #536 