### PR TITLE
Dockerfile - prepare for multi-architecture builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM golang:1.18-alpine as builder
 # RUN apk add --update git
 COPY . /server/
 WORKDIR /server/
-RUN go build -o ./bin/postee main.go
+ARG TARGETOS TARGETARCH
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build --ldflags "-s -w" -o ./bin/postee main.go
 
 FROM alpine:3.16.2
 RUN apk update && apk add wget ca-certificates curl jq

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -11,7 +11,8 @@ FROM golang:1.18-alpine as gobuilder
 COPY . /server
 WORKDIR /server/ui/backend
 RUN apk add git
-RUN go build -o posteeui
+ARG TARGETOS TARGETARCH
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build --ldflags "-s -w" -o posteeui
 
 FROM alpine:3.16.2
 EXPOSE 8001


### PR DESCRIPTION
- closes #553 
- buildx bake is setting two environment variables that we have to forward into the Dockerfile to prepare for multi architecture builds
- prepares for #541 