### PR TITLE
docs/advanced - mark variable name as code

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -40,7 +40,7 @@ Postee loads bundle of templates from `rego-templates` folder. This folder inclu
 To create your own template, you should create a new file under the 'rego-templates' directory, and use the
 [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/) for the actual template code.
 
-Message payload is referenced as `input` when template is rendered. The result variable should be used to store the output message, which is the result of the template formatting.
+Message payload is referenced as `input` when template is rendered. The `result` variable should be used to store the output message, which is the result of the template formatting.
 
 The following variables should be defined in the custom Rego template.
 


### PR DESCRIPTION
- improve readability
- first occasion is a variable name and thus it should be highlighted as code (as done for variable `input`)