### PR TITLE
feat(Helm): ensure Ingress API compability with Kubernetes > 1.19

### DIFF
--- a/deploy/helm/postee/Chart.yaml
+++ b/deploy/helm/postee/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Postee
 type: application
 
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/postee/templates/ingress.yaml
+++ b/deploy/helm/postee/templates/ingress.yaml
@@ -1,8 +1,10 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "postee.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.14-0 < 1.19.0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
@@ -27,6 +29,22 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+    {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+    {{- else -}}
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
@@ -37,5 +55,6 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
           {{- end }}
+    {{- end }}
     {{- end }}
   {{- end }}

--- a/deploy/helm/postee/values.yaml
+++ b/deploy/helm/postee/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 posteeConfig: |
   # The configuration file contains a general settings section,
   # routes, templates and actions sections.
-  
+
   name: tenant            #  The tenant name
   aqua-server:            #  URL of Aqua Server for links. E.g. https://myserver.aquasec.com
   max-db-size: 1000MB       #  Max size of DB. <numbers><unit suffix> pattern is used, such as "300MB" or "1GB". If empty or 0 then unlimited
@@ -35,7 +35,7 @@ posteeConfig: |
   #   aggregate-message-timeout:                  # Number of seconds/minutes/hours to aggregate same messages into one output. Maximum is 24 hours. Use Xs or Xm or Xh
   #   unique-message-props: ["digest","image","registry", "vulnerability_summary.high", "vulnerability_summary.medium", "vulnerability_summary.low"] # Optional: Comma separated list of top level properties which uniqult identifies an event message. If message with same property values is received more than once it will be ignored
   #   unique-message-timeout:                     # Number of seconds/minutes/hours/days before expiring of a message. Expired messages are removed from db. If option is empty message is never deleted
-  
+
   # - name: Trivy Operator Alerts
   #   input: input.report.summary.criticalCount > 0 # You can customize this based on your needs
   #   actions: [my-slack]
@@ -235,6 +235,7 @@ ingress:
     - host: chart-example.local
       paths:
       - path: /
+        pathType: Prefix
         backend:
           serviceName: chart-example.local
           servicePort: 80


### PR DESCRIPTION
While trying to deploy Postee with its Ingress into one of our clusters, I've noticed that the Kubernetes API didn't accept the Ingress.

That is, because the `networking.k8s.io/v1beta1` API is deprecated as of now.

With my changes, the Ingress should be compatible with any older k8s version, but also with all most recent versions.