### PR TITLE
fix: downgrade the Node.js image from 20 to 18

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.17 as vuebuilder
+FROM node:18-alpine3.17 as vuebuilder
 COPY ./ui/frontend /frontend
 WORKDIR /frontend
 


### PR DESCRIPTION
Postee UI contains a dependency that does not support node 20.

I have downgraded the Node image version to 18. This is the LTS version that will be supported until April 2025

Closes #564 