### PR TITLE
fix: creating issues in Jira 9.x.x

### DIFF
--- a/actions/jira_test.go
+++ b/actions/jira_test.go
@@ -658,7 +658,10 @@ func TestJiraAPI_CreateMetaProject(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ts := httptest.NewServer(http.HandlerFunc(buildHttpHandler(test.metaInfo, test.wantError)))
+			mux := http.NewServeMux()
+			mux.HandleFunc("/rest/api/2/issue/createmeta/", buildHttpHandler(test.metaInfo, test.wantError))
+			mux.HandleFunc("/rest/api/2/serverInfo", buildHttpHandler(&jira.JiraServerInfo{VersionNumbers: []int{8, 4, 0}}, test.wantError))
+			ts := httptest.NewServer(mux)
 			defer ts.Close()
 
 			jiraClient, err := jira.NewClient(ts.Client(), ts.URL)

--- a/actions/jira_test.go
+++ b/actions/jira_test.go
@@ -486,6 +486,7 @@ func TestJiraAPI_Send(t *testing.T) {
 		fieldList      *[]jira.Field
 		priorityList   *[]jira.Priority
 		issue          *jira.Issue
+		serverInfo     *jira.JiraServerInfo
 		content        map[string]string
 		wantError      string
 	}{
@@ -503,6 +504,7 @@ func TestJiraAPI_Send(t *testing.T) {
 			fieldList:      fieldList,
 			priorityList:   &[]jira.Priority{{Name: "High"}},
 			issue:          &jira.Issue{},
+			serverInfo:     &jira.JiraServerInfo{VersionNumbers: []int{8, 3, 0}},
 			content:        map[string]string{"title": "title_content", "description": "description_content"},
 		},
 		{
@@ -517,18 +519,21 @@ func TestJiraAPI_Send(t *testing.T) {
 		{
 			name:           "sad path (Failed to get issuetype)",
 			jiraApi:        &JiraAPI{Issuetype: "bogusIssueType", ProjectKey: "project"},
+			serverInfo:     &jira.JiraServerInfo{VersionNumbers: []int{8, 3, 0}},
 			createMetaInfo: &jira.CreateMetaInfo{Projects: []*jira.MetaProject{{Key: "project", IssueTypes: []*jira.MetaIssueType{metaIssuetype}}}},
 			wantError:      "Failed to get issuetype",
 		},
 		{
 			name:           "sad path (Failed to create fields config)",
 			jiraApi:        &JiraAPI{ProjectKey: "project"},
+			serverInfo:     &jira.JiraServerInfo{VersionNumbers: []int{8, 3, 0}},
 			createMetaInfo: &jira.CreateMetaInfo{Projects: []*jira.MetaProject{{Key: "project", IssueTypes: []*jira.MetaIssueType{metaIssuetype}}}},
 			wantError:      "Failed to create fields config",
 		},
 		{
 			name:           "sad path (Failed to init issue)",
 			jiraApi:        &JiraAPI{ProjectKey: "project", Unknowns: map[string]string{"bad field": "bad field"}},
+			serverInfo:     &jira.JiraServerInfo{VersionNumbers: []int{8, 3, 0}},
 			createMetaInfo: &jira.CreateMetaInfo{Projects: []*jira.MetaProject{{Key: "project", IssueTypes: []*jira.MetaIssueType{metaIssuetype}}}},
 			fieldList:      fieldList,
 			priorityList:   &[]jira.Priority{{Name: "High"}},
@@ -537,6 +542,7 @@ func TestJiraAPI_Send(t *testing.T) {
 		{
 			name:           "sad path (Failed to open issue)",
 			jiraApi:        &JiraAPI{ProjectKey: "project"},
+			serverInfo:     &jira.JiraServerInfo{VersionNumbers: []int{8, 3, 0}},
 			createMetaInfo: &jira.CreateMetaInfo{Projects: []*jira.MetaProject{{Key: "project", IssueTypes: []*jira.MetaIssueType{metaIssuetype}}}},
 			fieldList:      fieldList,
 			priorityList:   &[]jira.Priority{{Name: "High"}},
@@ -550,10 +556,11 @@ func TestJiraAPI_Send(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mux := http.NewServeMux()
-			mux.HandleFunc("/rest/api/2/issue/createmeta", buildHttpHandler(test.createMetaInfo, test.wantError))
+			mux.HandleFunc("/rest/api/2/issue/createmeta/", buildHttpHandler(test.createMetaInfo, test.wantError))
 			mux.HandleFunc("/rest/api/2/field", buildHttpHandler(test.fieldList, test.wantError))
 			mux.HandleFunc("/rest/api/2/priority", buildHttpHandler(test.priorityList, test.wantError))
 			mux.HandleFunc("/rest/api/2/issue", buildHttpHandler(test.issue, test.wantError))
+			mux.HandleFunc("/rest/api/2/serverInfo", buildHttpHandler(test.serverInfo, test.wantError))
 			ts := httptest.NewServer(mux)
 			defer ts.Close()
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/PagerDuty/go-pagerduty v1.5.1
-	github.com/aquasecurity/go-jira v0.0.0-20211103111421-b62ce48827be
+	github.com/aquasecurity/go-jira v0.0.0-20230606054137-358abd58fd26
 	github.com/aws/aws-sdk-go-v2 v1.16.11
 	github.com/aws/aws-sdk-go-v2/config v1.17.1
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.22.7

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
-github.com/aquasecurity/go-jira v0.0.0-20211103111421-b62ce48827be h1:xUasZnauNAn2jY0gfVG+Ro371S31s3SfVUvcjhwIMyI=
-github.com/aquasecurity/go-jira v0.0.0-20211103111421-b62ce48827be/go.mod h1:IHtKzIAdk0t3Xse7rJSY7pJlA8gB7lqY2b4l5WYZYsk=
+github.com/aquasecurity/go-jira v0.0.0-20230606054137-358abd58fd26 h1:1/tjfCdtYFWEkDQ1fZ23/wgeIweVCk77qeL12fOWCKM=
+github.com/aquasecurity/go-jira v0.0.0-20230606054137-358abd58fd26/go.mod h1:IHtKzIAdk0t3Xse7rJSY7pJlA8gB7lqY2b4l5WYZYsk=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=


### PR DESCRIPTION
Jira 9.x had breaking changes - Atlassian removed [createmeta REST endpoint](https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html). so we updated [aquasecurity/go-jira](https://github.com/aquasecurity/go-jira).

before:
```sh
2023/06/06 12:31:37 Error while sending event: Failed to create meta project: failed to get create meta : request failed. Please analyze the request body for more details. Status code: 404
```
after:
```sh
2023/06/06 12:31:38 Created new jira issue 10000
```
