### PR TITLE
feat: Add curl and jq to release image

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,5 +1,9 @@
 FROM alpine:3.18.0
-RUN  apk add --no-cache wget ca-certificates
+RUN apk add --no-cache \
+  ca-certificates \
+  curl \
+  jq \
+  wget
 EXPOSE 8082
 EXPOSE 8445
 RUN mkdir /server


### PR DESCRIPTION
Resolves #548 - adds curl and jq to the release image.

The apk command is changed to download the index only one time. Afterwards the cache is cleared.

