### PR TITLE
feat: add dependency track integration

### DIFF
--- a/actions/dependencytrack.go
+++ b/actions/dependencytrack.go
@@ -1,0 +1,75 @@
+package actions
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	dtrack "github.com/DependencyTrack/client-go"
+	"github.com/aquasecurity/postee/v2/formatting"
+	"github.com/aquasecurity/postee/v2/layout"
+)
+
+type DependencyTrackAction struct {
+	Name   string
+	Url    string
+	APIKey string
+}
+
+func (dta *DependencyTrackAction) GetName() string {
+	return dta.Name
+}
+
+func (dta *DependencyTrackAction) Init() error {
+	log.Printf("Starting Dependency Track action %s, for sending to %s", dta.Name, dta.Url)
+	return nil
+}
+
+func (dta *DependencyTrackAction) Send(content map[string]string) error {
+	project, ok := content["title"]
+	if !ok && project == "" {
+		return fmt.Errorf("title key not found")
+	}
+
+	projectAndVersion := strings.SplitN(project, ":", 2)
+	if len(projectAndVersion) != 2 {
+		return fmt.Errorf("title key has wrong format")
+	}
+
+	bom, err := json.Marshal(json.RawMessage(content["description"]))
+	if err != nil {
+		return fmt.Errorf("description key has wrong format: %w", err)
+	}
+
+	client, err := dtrack.NewClient(dta.Url, dtrack.WithAPIKey(dta.APIKey))
+	if err != nil {
+		return fmt.Errorf("failed to create dependency track client: %w", err)
+	}
+
+	ctx := context.Background()
+
+	_, err = client.BOM.Upload(ctx, dtrack.BOMUploadRequest{
+		ProjectName:    projectAndVersion[0],
+		ProjectVersion: projectAndVersion[1],
+		AutoCreate:     true,
+		BOM:            base64.StdEncoding.EncodeToString(bom),
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to upload BOM: %w", err)
+	}
+
+	return nil
+}
+
+func (dta *DependencyTrackAction) Terminate() error {
+	log.Printf("Dependency Track action %s terminated.", dta.Name)
+	return nil
+}
+
+func (dta *DependencyTrackAction) GetLayoutProvider() layout.LayoutProvider {
+	return new(formatting.HtmlProvider)
+}

--- a/actions/dependencytrack.go
+++ b/actions/dependencytrack.go
@@ -62,6 +62,8 @@ func (dta *DependencyTrackAction) Send(content map[string]string) error {
 		return fmt.Errorf("failed to upload BOM: %w", err)
 	}
 
+	log.Printf("successfully sent: %q to Dependency Track", dta.Name)
+
 	return nil
 }
 

--- a/actions/dependencytrack_test.go
+++ b/actions/dependencytrack_test.go
@@ -1,0 +1,189 @@
+package actions
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDependencyTrackAction_Send(t *testing.T) {
+	bomJSON := `{
+		"$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+		"bomFormat": "CycloneDX",
+		"specVersion": "1.4",
+		"serialNumber": "urn:uuid:78f7eeb2-25fd-45ce-9ece-63cf0ca9b1af",
+		"version": 1,
+		"metadata": {
+		  "timestamp": "2023-07-26T07:42:41+00:00",
+		  "tools": [
+			{
+			  "vendor": "aquasecurity",
+			  "name": "trivy",
+			  "version": "0.43.1"
+			}
+		  ],
+		  "component": {
+			"bom-ref": "pkg:oci/busybox@sha256:caa382c432891547782ce7140fb3b7304613d3b0438834dce1cad68896ab110a?repository_url=index.docker.io%2Flibrary%2Fbusybox\u0026arch=arm64",
+			"type": "container",
+			"name": "busybox:latest",
+			"purl": "pkg:oci/busybox@sha256:caa382c432891547782ce7140fb3b7304613d3b0438834dce1cad68896ab110a?repository_url=index.docker.io%2Flibrary%2Fbusybox\u0026arch=arm64",
+			"properties": [
+			  {
+				"name": "aquasecurity:trivy:DiffID",
+				"value": "sha256:57d0c5e3b21e4fdac106cfee383d702b92cd433e6e45588153228670b616bc59"
+			  },
+			  {
+				"name": "aquasecurity:trivy:ImageID",
+				"value": "sha256:d38589532d9756ff743d2149a143bfad79833261ff18c24b22088183a651ff65"
+			  },
+			  {
+				"name": "aquasecurity:trivy:RepoDigest",
+				"value": "busybox@sha256:caa382c432891547782ce7140fb3b7304613d3b0438834dce1cad68896ab110a"
+			  },
+			  {
+				"name": "aquasecurity:trivy:RepoTag",
+				"value": "busybox:latest"
+			  },
+			  {
+				"name": "aquasecurity:trivy:SchemaVersion",
+				"value": "2"
+			  }
+			]
+		  }
+		},
+		"components": [],
+		"dependencies": [
+		  {
+			"ref": "pkg:oci/busybox@sha256:caa382c432891547782ce7140fb3b7304613d3b0438834dce1cad68896ab110a?repository_url=index.docker.io%2Flibrary%2Fbusybox\u0026arch=arm64",
+			"dependsOn": []
+		  }
+		],
+		"vulnerabilities": []
+	  }`
+	type fields struct {
+		Name   string
+		Url    string
+		APIKey string
+	}
+	type args struct {
+		content map[string]string
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		args        args
+		wantErr     string
+		errMsg      string
+		handlerFunc http.HandlerFunc
+	}{
+		{
+			name: "valid content JSON BOM",
+			fields: fields{
+				Name:   "test",
+				APIKey: "key",
+			},
+			args: args{
+				content: map[string]string{
+					"title":       "test-project:test-version",
+					"description": bomJSON,
+				},
+			},
+			handlerFunc: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, err := w.Write([]byte(`{"token":"6026693d-b182-4569-8ba1-0b2c0cc509be"}`))
+				if err != nil {
+					panic(err)
+				}
+			}),
+		},
+		{
+			name: "not found title",
+			fields: fields{
+				Name:   "test",
+				APIKey: "key",
+			},
+			args: args{
+				content: map[string]string{
+					"description": bomJSON,
+				},
+			},
+			wantErr: "title key not found",
+		},
+		{
+			name: "invalid title format",
+			fields: fields{
+				Name:   "test",
+				APIKey: "key",
+			},
+			args: args{
+				content: map[string]string{
+					"title":       "invalid",
+					"description": bomJSON,
+				},
+			},
+			wantErr: "title key has wrong format",
+		},
+		{
+			name: "invalid description format",
+			fields: fields{
+				Name:   "test",
+				APIKey: "key",
+			},
+			args: args{
+				content: map[string]string{
+					"title":       "test-project:test-version",
+					"description": "invalid",
+				},
+			},
+			wantErr: "description key has wrong format: json: error calling MarshalJSON for type json.RawMessage: invalid character 'i' looking for beginning of value",
+			handlerFunc: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}),
+		},
+		{
+			name: "failed to upload BOM",
+			fields: fields{
+				Name:   "test",
+				APIKey: "invalid",
+			},
+			args: args{
+				content: map[string]string{
+					"title":       "test-project:test-version",
+					"description": bomJSON,
+				},
+			},
+			wantErr: "failed to upload BOM: api error (status: 401)",
+			handlerFunc: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(tt.handlerFunc)
+			defer ts.Close()
+
+			url := tt.fields.Url
+			if url == "" {
+				url = ts.URL
+			}
+
+			dta := &DependencyTrackAction{
+				Name:   tt.fields.Name,
+				Url:    url,
+				APIKey: tt.fields.APIKey,
+			}
+
+			err := dta.Send(tt.args.content)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err, tt.name)
+			}
+		})
+	}
+}

--- a/cfg.yaml
+++ b/cfg.yaml
@@ -52,6 +52,8 @@ templates:
   rego-package: postee.vuls.cyclondx
 - name: trivy-operator-slack
   rego-package: postee.trivyoperator.slack
+- name: trivy-operator-dependencytrack
+  rego-package: postee.trivyoperator.dependencytrack
 - name: trivy-jira
   rego-package: postee.trivy.jira
 
@@ -140,6 +142,12 @@ actions:
   password:         # Mandatory. User password
   url:              # Mandatory. Url of Nexus IQ server
   organization-id:  # Mandatory. Organization UID like "222de33e8005408a844c12eab952c9b0"
+
+  - name: my-dependencytrack
+    type: dependencytrack
+    enable: false
+    url:                       # Mandatory. Url of Dependency Track server
+    dependency-track-api-key:  # Mandatory. API key of Dependency Track server
 
 - name: my-opsgenie
   type: opsgenie

--- a/cfg.yaml
+++ b/cfg.yaml
@@ -146,8 +146,8 @@ actions:
   - name: my-dependencytrack
     type: dependencytrack
     enable: false
-    url:                       # Mandatory. Url of Dependency Track server
-    dependency-track-api-key:  # Mandatory. API key of Dependency Track server
+    url: http://localhost:8080/  # Mandatory. Url of Dependency Track server
+    dependency-track-api-key:    # Mandatory. API key of Dependency Track server
 
 - name: my-opsgenie
   type: opsgenie

--- a/deploy/helm/postee/values.yaml
+++ b/deploy/helm/postee/values.yaml
@@ -41,6 +41,11 @@ posteeConfig: |
   #   actions: [my-slack]
   #   template: trivy-operator-slack
 
+  # - name: Trivy Operator Sbom Report to Dependency Track
+  #   input: contains(input.kind, "SbomReport")
+  #   actions: [ my-dependencytrack ]
+  #   template: trivy-operator-dependencytrack
+
   # Templates are used to format a message
   templates:
   - name: vuls-slack                  #  Out of the box template for slack
@@ -63,6 +68,8 @@ posteeConfig: |
     rego-package: postee.vuls.cyclondx
   - name: trivy-operator-slack
     rego-package: postee.trivyoperator.slack
+  - name: trivy-operator-dependencytrack
+    rego-package: postee.trivyoperator.dependencytrack
 
   # Rules are predefined rego policies that can be used to trigger routes
   rules:
@@ -149,6 +156,12 @@ posteeConfig: |
     password:         # Mandatory. User password
     url:              # Mandatory. Url of Nexus IQ server
     organization-id:  # Mandatory. Organization UID like "222de33e8005408a844c12eab952c9b0"
+
+  - name: my-dependencytrack
+    type: dependencytrack
+    enable: false
+    url:                       # Mandatory. Url of Dependency Track
+    dependency-track-api-key:  # Mandatory. API key of Dependency Track
 
   - name: my-opsgenie
     type: opsgenie

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -193,6 +193,13 @@ Key               | Description                                              | V
 *url*             | Url of Nexus IQ server                                   |                 | Yes
 *organization-id* | Organization UID like "222de33e8005408a844c12eab952c9b0" |                 | Yes
 
+## Dependency Track
+
+Key                        | Description                    | Values  | Required  
+-------------------------- | ------------------------------ | ------- | --------  
+*url*                      | Url of Dependency Track        |         | Yes
+*dependency-track-api-key* | API key of Dependency Track    |         | Yes
+
 ## OpsGenie
 
 ??? note "Set up OpsGenie and get a token"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aquasecurity/postee/v2
 go 1.18
 
 require (
+	github.com/DependencyTrack/client-go v0.11.0
 	github.com/PagerDuty/go-pagerduty v1.5.1
 	github.com/aquasecurity/go-jira v0.0.0-20230705211506-0cd878ce5449
 	github.com/aws/aws-sdk-go-v2 v1.16.11
@@ -11,7 +12,7 @@ require (
 	github.com/aws/smithy-go v1.12.1
 	github.com/docker/docker v20.10.24+incompatible
 	github.com/ghodss/yaml v1.0.0
-	github.com/google/uuid v1.2.0
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/nats-io/nats-server/v2 v2.7.4
 	github.com/nats-io/nats.go v1.13.1-0.20220308171302-2f2f6968e98d
@@ -20,7 +21,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799
 	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.10
 	github.com/spf13/cobra v1.5.0
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.2
 	github.com/tidwall/gjson v1.14.0
 	go.etcd.io/bbolt v1.3.6
 	k8s.io/api v0.23.3
@@ -51,7 +52,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DependencyTrack/client-go v0.11.0 h1:1g+eHC8nJyIzi68zcs+dr3OHRvS1aC+4Uy3YKA0JJhc=
+github.com/DependencyTrack/client-go v0.11.0/go.mod h1:XLZnOksOs56Svq+K4xmBkN8U97gpP7r1BkhCc/xA8Iw=
 github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=
 github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -216,6 +218,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
@@ -241,6 +245,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
@@ -372,6 +378,7 @@ github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -381,6 +388,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tchap/go-patricia/v2 v2.3.1 h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BGhTkes=
 github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/tidwall/gjson v1.14.0 h1:6aeJ0bzojgWLa82gDQHcx3S0Lr/O51I9bJ5nv6JFx5w=

--- a/rego-templates/trivy-operator-dependency-track.rego
+++ b/rego-templates/trivy-operator-dependency-track.rego
@@ -1,0 +1,5 @@
+package postee.trivyoperator.dependencytrack
+
+title:=sprintf("%s:%s", [input.report.artifact.repository, input.report.artifact.tag])
+
+result:=input.report.components

--- a/router/builders.go
+++ b/router/builders.go
@@ -84,6 +84,14 @@ func buildNexusIqAction(sourceSettings *ActionSettings) *actions.NexusIqAction {
 	}
 }
 
+func buildDependencyTrackAction(sourceSettings *ActionSettings) *actions.DependencyTrackAction {
+	return &actions.DependencyTrackAction{
+		Name:   sourceSettings.Name,
+		Url:    sourceSettings.Url,
+		APIKey: sourceSettings.DependencyTrackAPIKey,
+	}
+}
+
 func buildOpsGenieAction(sourceSettings *ActionSettings) *actions.OpsGenieAction {
 	return &actions.OpsGenieAction{
 		Name:           sourceSettings.Name,

--- a/router/initoutputs_test.go
+++ b/router/initoutputs_test.go
@@ -87,6 +87,21 @@ func TestBuildAndInitOtpt(t *testing.T) {
 			"*actions.NexusIqAction",
 		},
 		{
+			"Simple Dependency Track action",
+			ActionSettings{
+				Url:                   "http://localhost:8080",
+				Name:                  "my-dependencytrack",
+				Type:                  "dependencytrack",
+				DependencyTrackAPIKey: "api-key",
+			},
+			map[string]interface{}{
+				"Url":    "http://localhost:8080",
+				"APIKey": "api-key",
+			},
+			false,
+			"*actions.DependencyTrackAction",
+		},
+		{
 			"Simple Jira action",
 			ActionSettings{
 				Url:        "localhost:2990",

--- a/router/integrations.go
+++ b/router/integrations.go
@@ -1,54 +1,55 @@
 package router
 
 type ActionSettings struct {
-	Name                string                       `json:"name,omitempty"`
-	Type                string                       `json:"type,omitempty"`
-	RunsOn              string                       `json:"runs-on,omitempty"`
-	Enable              bool                         `json:"enable,omitempty"`
-	Url                 string                       `json:"url,omitempty"`
-	User                string                       `json:"user,omitempty"`
-	Password            string                       `json:"password,omitempty"`
-	TlsVerify           bool                         `json:"tls-verify,omitempty"`
-	ProjectKey          string                       `json:"project-key,omitempty" structs:"project-key,omitempty"`
-	IssueType           string                       `json:"issuetype,omitempty" structs:"issuetype"`
-	BoardName           string                       `json:"board,omitempty" structs:"board,omitempty"`
-	Priority            string                       `json:"priority,omitempty"`
-	Assignee            []string                     `json:"assignee,omitempty"`
-	Summary             string                       `json:"summary,omitempty"`
-	FixVersions         []string                     `json:"fix-versions,omitempty"`
-	AffectsVersions     []string                     `json:"affects-versions,omitempty"`
-	Labels              []string                     `json:"labels,omitempty"`
-	Sprint              string                       `json:"sprint,omitempty"`
-	Unknowns            map[string]string            `json:"unknowns,omitempty" structs:"unknowns,omitempty"`
-	Host                string                       `json:"host,omitempty"`
-	Port                int                          `json:"port,omitempty"`
-	Recipients          []string                     `json:"recipients,omitempty"`
-	Sender              string                       `json:"sender,omitempty"`
-	Token               string                       `json:"token,omitempty"`
-	UseMX               bool                         `json:"use-mx,omitempty"`
-	InstanceName        string                       `json:"instance,omitempty"`
-	SizeLimit           int                          `json:"size-limit,omitempty"`
-	InputFile           string                       `json:"input-file,omitempty"`
-	ExecScript          string                       `json:"exec-script,omitempty"`
-	Env                 []string                     `json:"env,omitempty"`
-	BodyFile            string                       `json:"body-file,omitempty"`
-	BodyContent         string                       `json:"body-content,omitempty"`
-	Method              string                       `json:"method,omitempty"`
-	Timeout             string                       `json:"timeout,omitempty"`
-	Headers             map[string][]string          `json:"headers,omitempty"`
-	OrganizationId      string                       `json:"organization-id,omitempty"`
-	KubeConfigFile      string                       `json:"kube-config-file,omitempty"`
-	KubeLabelSelector   string                       `json:"kube-label-selector,omitempty"`
-	KubeActions         map[string]map[string]string `json:"kube-actions,omitempty"`
-	KubeNamespace       string                       `json:"kube-namespace,omitempty"`
-	DockerImageName     string                       `json:"docker-image-name,omitempty"`
-	DockerNetwork       string                       `json:"docker-network,omitempty"`
-	DockerCmd           []string                     `json:"docker-cmd,omitempty"`
-	DockerVolumes       map[string]string            `json:"docker-volume-mounts,omitempty"`
-	DockerEnv           []string                     `json:"docker-env,omitempty"`
-	Tags                []string                     `json:"tags,omitempty"`
-	Alias               string                       `json:"alias,omitempty"`
-	Entity              string                       `json:"entity,omitempty"`
-	PagerdutyAuthToken  string                       `json:"pagerduty-auth-token,omitempty"`
-	PagerdutyRoutingKey string                       `json:"pagerduty-routing-key,omitempty"`
+	Name                  string                       `json:"name,omitempty"`
+	Type                  string                       `json:"type,omitempty"`
+	RunsOn                string                       `json:"runs-on,omitempty"`
+	Enable                bool                         `json:"enable,omitempty"`
+	Url                   string                       `json:"url,omitempty"`
+	User                  string                       `json:"user,omitempty"`
+	Password              string                       `json:"password,omitempty"`
+	TlsVerify             bool                         `json:"tls-verify,omitempty"`
+	ProjectKey            string                       `json:"project-key,omitempty" structs:"project-key,omitempty"`
+	IssueType             string                       `json:"issuetype,omitempty" structs:"issuetype"`
+	BoardName             string                       `json:"board,omitempty" structs:"board,omitempty"`
+	Priority              string                       `json:"priority,omitempty"`
+	Assignee              []string                     `json:"assignee,omitempty"`
+	Summary               string                       `json:"summary,omitempty"`
+	FixVersions           []string                     `json:"fix-versions,omitempty"`
+	AffectsVersions       []string                     `json:"affects-versions,omitempty"`
+	Labels                []string                     `json:"labels,omitempty"`
+	Sprint                string                       `json:"sprint,omitempty"`
+	Unknowns              map[string]string            `json:"unknowns,omitempty" structs:"unknowns,omitempty"`
+	Host                  string                       `json:"host,omitempty"`
+	Port                  int                          `json:"port,omitempty"`
+	Recipients            []string                     `json:"recipients,omitempty"`
+	Sender                string                       `json:"sender,omitempty"`
+	Token                 string                       `json:"token,omitempty"`
+	UseMX                 bool                         `json:"use-mx,omitempty"`
+	InstanceName          string                       `json:"instance,omitempty"`
+	SizeLimit             int                          `json:"size-limit,omitempty"`
+	InputFile             string                       `json:"input-file,omitempty"`
+	ExecScript            string                       `json:"exec-script,omitempty"`
+	Env                   []string                     `json:"env,omitempty"`
+	BodyFile              string                       `json:"body-file,omitempty"`
+	BodyContent           string                       `json:"body-content,omitempty"`
+	Method                string                       `json:"method,omitempty"`
+	Timeout               string                       `json:"timeout,omitempty"`
+	Headers               map[string][]string          `json:"headers,omitempty"`
+	OrganizationId        string                       `json:"organization-id,omitempty"`
+	KubeConfigFile        string                       `json:"kube-config-file,omitempty"`
+	KubeLabelSelector     string                       `json:"kube-label-selector,omitempty"`
+	KubeActions           map[string]map[string]string `json:"kube-actions,omitempty"`
+	KubeNamespace         string                       `json:"kube-namespace,omitempty"`
+	DockerImageName       string                       `json:"docker-image-name,omitempty"`
+	DockerNetwork         string                       `json:"docker-network,omitempty"`
+	DockerCmd             []string                     `json:"docker-cmd,omitempty"`
+	DockerVolumes         map[string]string            `json:"docker-volume-mounts,omitempty"`
+	DockerEnv             []string                     `json:"docker-env,omitempty"`
+	Tags                  []string                     `json:"tags,omitempty"`
+	Alias                 string                       `json:"alias,omitempty"`
+	Entity                string                       `json:"entity,omitempty"`
+	PagerdutyAuthToken    string                       `json:"pagerduty-auth-token,omitempty"`
+	PagerdutyRoutingKey   string                       `json:"pagerduty-routing-key,omitempty"`
+	DependencyTrackAPIKey string                       `json:"dependency-track-api-key,omitempty"`
 }

--- a/router/router.go
+++ b/router/router.go
@@ -401,6 +401,8 @@ func BuildAndInitOtpt(settings *ActionSettings, aquaServerUrl string) actions.Ac
 		plg = buildStdoutAction(settings)
 	case "nexusiq":
 		plg = buildNexusIqAction(settings)
+	case "dependencytrack":
+		plg = buildDependencyTrackAction(settings)
 	case "opsgenie":
 		plg = buildOpsGenieAction(settings)
 	case "exec":

--- a/ui/frontend/src/components/ActionDetails.vue
+++ b/ui/frontend/src/components/ActionDetails.vue
@@ -48,6 +48,7 @@
                   <option value="splunk">Splunk</option>
                   <option value="serviceNow">ServiceNow</option>
                   <option value="nexusIq">Nexus IQ</option>
+                  <option value="dependencytrack">Dependency Track</option>
                   <option value="exec">Exec</option>
                   <option value="awssecurityhub">AWS Security Hub</option>
                 </select>
@@ -121,6 +122,19 @@
             name="organization-id"
             description="ID of organization to create reports in"
             :show="isNexusIQ"
+            :inputHandler="updateField"
+            :validator="v(required)"
+          />
+          <!-- -->
+          <!-- dependencytrack custom properties start -->
+          <PropertyField
+            id="dependencyTrackApiKey"
+            label="Dependency Track API Key"
+            :value="formValues['dependency-track-api-key']"
+            :errorMsg="errors['dependencyTrackApiKey']"
+            name="dependency-track-api-key"
+            description="Key for API to upload BOM to Dependency Track"
+            :show="isDependencyTrack"
             :inputHandler="updateField"
             :validator="v(required)"
           />
@@ -493,6 +507,7 @@ const urlDescriptionByType = {
   jira: 'Mandatory. E.g "https://johndoe.atlassian.net"',
   slack: "",
   nexusIq: "Url of Nexus IQ server",
+  dependencytrack: "Url of Dependency Track server",
 };
 const typesWithCredentials = ["serviceNow", "email", "nexusIq"]; //TODO add description strings
 
@@ -551,6 +566,9 @@ export default {
     },
     isNexusIQ() {
       return this.actionType === "nexusIq";
+    },
+    isDependencyTrack() {
+      return this.actionType === "dependencytrack";
     },
     isExec(){
       return this.actionType === "exec";


### PR DESCRIPTION
ref https://github.com/aquasecurity/postee/issues/575

SBOM Report has been supported since Trivy Operator [0.15.0](https://github.com/aquasecurity/trivy-operator/releases/tag/v0.15.0) .

I want to execute a webhook to Dependency Track via Postee. (ref: https://github.com/aquasecurity/trivy-operator/issues/143#issuecomment-1582164314 )

In this Pull Request, I implemented the following:

- Added Integration of Dependency Track
- Added Template for sending Trivy Operator sbomReport to Dependency Track

Dependency Track uploads the BOM with ProjectName and ProjectVersion as keys.

Dependency Track Integration has the following specification:

- `ProjectName:ProjectVersion` is the template `title` .  (e.g. `busybox:latest`)
- BOM data is in the template `description` .

In this Pull Request, only JSON used by trivy-operator is supported as BOM format.

---

The operation was checked in the following environment.

- Dependency Track 4.8.0
- Trivy Operator 0.15.**1** (ref: https://github.com/aquasecurity/trivy-operator/pull/1378)

```
routes:
  - name: dependencytrack
    input: contains(input.kind, "SbomReport")
    actions: [ dependencytrack ]
    template: dependencytrack
actions:
  - name: my-dependencytrack
    type: dependencytrack
    enable: true
    url: http://192.168.100.28:8081/ # local docker compose
    dependency-track-api-key: **
templates:
  - name: dependencytrack
    rego-package: postee.trivyoperator.dependencytrack
```

- trivy-operator sends SBOM Report webhook to Postee and is registered in Dependency Track.
- Can be configured from Postee UI
  <img width="821" alt="image" src="https://github.com/aquasecurity/postee/assets/10905048/5d86308f-546f-48cf-97af-054d386e4c44">
