### PR TITLE
chore: image tag uses the default `.Chart.AppVersion`

### DIFF
--- a/deploy/helm/postee/values.yaml
+++ b/deploy/helm/postee/values.yaml
@@ -186,7 +186,9 @@ posteUi:
     # usernameKey: username
     # passwordKey: password
   image: aquasec/postee-ui
-  # tag: "2.12.0-amd64"
+  # By default `tag` is taken from `.Chart.AppVersion`
+  # To use different version - uncomment this line and enter the desired version
+  # tag: ""
 
 configuration:
   # If set to true, ensure the externally generated secret to be named

--- a/deploy/helm/postee/values.yaml
+++ b/deploy/helm/postee/values.yaml
@@ -186,7 +186,7 @@ posteUi:
     # usernameKey: username
     # passwordKey: password
   image: aquasec/postee-ui
-  tag: "2.12.0-amd64"
+  # tag: "2.12.0-amd64"
 
 configuration:
   # If set to true, ensure the externally generated secret to be named
@@ -197,7 +197,7 @@ configuration:
 image:
   repository: aquasec/postee
   pullPolicy: Always
-  tag: "2.12.0-amd64"
+  # tag: "2.12.0-amd64"
 imageInit:
   repository: busybox
   pullPolicy: IfNotPresent

--- a/deploy/helm/postee/values.yaml
+++ b/deploy/helm/postee/values.yaml
@@ -199,7 +199,9 @@ configuration:
 image:
   repository: aquasec/postee
   pullPolicy: Always
-  # tag: "2.12.0-amd64"
+  # By default `tag` is taken from `.Chart.AppVersion`
+  # To use different version - uncomment this line and enter the desired version
+  # tag: ""
 imageInit:
   repository: busybox
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Ref: https://github.com/aquasecurity/postee/issues/605

Currently, the image tag in values.yaml is used instead of `.Chart.AppVersion`. This means that the tag must be incremented each time it is released.

In this pull request, remove the tag specification in values.yaml and use the default `.Chart.AppVersion`.

https://github.com/aquasecurity/postee/blob/698003ebe7b0ded95b07f010b5fee5942b91eeee/deploy/helm/postee/templates/postee.yaml#L85

https://github.com/aquasecurity/postee/blob/698003ebe7b0ded95b07f010b5fee5942b91eeee/deploy/helm/postee/templates/postee-ui.yaml#L43

The tag in values.yaml is commented out for documentation.

```shell
$ helm template deploy/helm/postee | grep 'image: "aquasec/postee' -A4 -B4
      containers:
        - name: postee
          securityContext:
            {}
          image: "aquasec/postee-ui:2.14.0-amd64"
          imagePullPolicy: Always
          env:
            - name: POSTEE_UI_CFG
              value: /data/cfg.yaml
--
      containers:
        - name: postee
          securityContext:
            {}
          image: "aquasec/postee:2.14.0-amd64"
          imagePullPolicy: Always
          env:
            - name: POSTEE_CFG
              value: /data/cfg.yaml
```