### PR TITLE
template examples - fix package name for defect dojo examples

### DIFF
--- a/config/cfg-trivy-operator-defectdojo.yaml
+++ b/config/cfg-trivy-operator-defectdojo.yaml
@@ -10,7 +10,7 @@ db-verify-interval: 1   #  How often to check the DB size. By default, Postee ch
 routes:
 - name: trivyScans
   actions: [ exec-curl-dd ]
-  template: plejd-dd-trivy-report
+  template: dd-trivy-report
   input: contains(input.kind, "ClusterRbacAssessmentReport")
 
 # Actions are target services that should consume the messages
@@ -30,5 +30,5 @@ templates:
 - name: raw-json                        # route message "As Is" to external webhook
   rego-package: postee.rawmessage.json
 
-- name: plejd-dd-trivy-report           # render from report into DD structure
-  rego-package: plejd.trivyoperator.defectdojo
+- name: dd-trivy-report           # render from report into DD structure
+  rego-package: postee.trivyoperator.defectdojo

--- a/rego-templates/example/defectdojo/trivy-operator-defectdojo.rego
+++ b/rego-templates/example/defectdojo/trivy-operator-defectdojo.rego
@@ -1,7 +1,7 @@
 # METADATA
 # title: trivy-operator-defectdojo
 # scope: package
-package plejd.trivyoperator.defectdojo
+package postee.trivyoperator.defectdojo
 
 title:="-" #not used with webhook
 

--- a/rego-templates/example/defectdojo/trivy-operator-defectdojo_test.rego
+++ b/rego-templates/example/defectdojo/trivy-operator-defectdojo_test.rego
@@ -1,6 +1,6 @@
-package plejd.trivyoperator.defectdojo.test
+package postee.trivyoperator.defectdojo.test
 
-import data.plejd.trivyoperator.defectdojo.result
+import data.postee.trivyoperator.defectdojo.result
 
 
 test_a_allowed {


### PR DESCRIPTION
- it is obviously not working when having another top-level name than "postee" in Rego packages
- so every REGO package used inside Postee has to follow that naming convention - is that the case
- this PR changes all package references in all examples related to DefectDojo