### PR TITLE
add support for .spec.topologySpreadConstraints on Postee server

### DIFF
--- a/deploy/helm/postee/templates/postee.yaml
+++ b/deploy/helm/postee/templates/postee.yaml
@@ -117,6 +117,10 @@ spec:
 {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - secret:
             secretName: {{ $fullName }}-secret

--- a/deploy/helm/postee/values.yaml
+++ b/deploy/helm/postee/values.yaml
@@ -210,6 +210,7 @@ imageInit:
   tag: "1.34"
 
 imagePullSecrets: []
+topologySpreadConstraints: []
 nameOverride: ""
 fullnameOverride: ""
 
@@ -280,6 +281,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
- solves #617
- allow the end user to define topologySpreadConstraints
- we focus on server instance first because we do not think that it is that important to spread the UI to different availability zones