### PR TITLE
Dockerfile - update to alpine:3.18.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /server/
 ARG TARGETOS TARGETARCH
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build --ldflags "-s -w" -o ./bin/postee main.go
 
-FROM alpine:3.18.2
+FROM alpine:3.18.4
 RUN apk update && apk add wget ca-certificates curl jq
 EXPOSE 8082
 EXPOSE 8445

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM alpine:3.18.2
+FROM alpine:3.18.4
 RUN apk add --no-cache \
   ca-certificates \
   curl \

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -14,7 +14,7 @@ RUN apk add git
 ARG TARGETOS TARGETARCH
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build --ldflags "-s -w" -o posteeui
 
-FROM alpine:3.18.2
+FROM alpine:3.18.4
 EXPOSE 8001
 
 RUN mkdir /uiserver


### PR DESCRIPTION
- get rid of busybox version with CVE
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-48174