### PR TITLE
Postee | Templates | Align vuls templates to the type of the scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,12 +190,12 @@ input: |
 <details>
 <summary>Details</summary>
 
-Key | Description | Possible Values | Example
---- | --- | --- | ---
-*aggregate-message-number*|Number of messages to aggregate into one message.| any integer value | 10
-*aggregate-message-timeout*|number of seconds, minutes, hours to aggregate|Maximum is 24 hours Xs or Xm or Xh | 1h
-*unique-message-props*|Optional. Comma separated list of properties which uniquely identifies an event message. If message with same property values is received more than once, consequitive messages will be ignored. | Array of properties that their value uniquely identifies a message | To avoid duplicate scanning messages you can use the following properties: ```unique-message-props: ["digest","image","registry", "vulnerability_summary.high", "vulnerability_summary.medium", "vulnerability_summary.low"]```
-*unique-message-timeout*|Optional. Used along with *unique-message-props*, has no effect if unique props are not specified. Number of seconds/minutes/hours/days before expiring of a message. Expired messages are removed from db. If option is empty message is never deleted | 1d
+Key | Description                                                                                                                                                                                                                                            | Possible Values | Example
+--- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| --- | ---
+*aggregate-message-number*| Number of messages to aggregate into one message.                                                                                                                                                                                                      | any integer value | 10
+*aggregate-message-timeout*| number of seconds, minutes, hours to aggregate                                                                                                                                                                                                         |Maximum is 24 hours Xs or Xm or Xh | 1h
+*unique-message-props*| Optional. Comma separated list of properties which uniquely identifies an event message. If message with same property values is received more than once, consecutive messages will be ignored.                                                        | Array of properties that their value uniquely identifies a message | To avoid duplicate scanning messages you can use the following properties: ```unique-message-props: ["digest","image","registry", "vulnerability_summary.high", "vulnerability_summary.medium", "vulnerability_summary.low"]```
+*unique-message-timeout*| Optional. Used along with *unique-message-props*, has no effect if unique props are not specified. Number of seconds/minutes/hours/days before expiring of a message. Expired messages are removed from db. If option is empty message is never deleted | 1d
 </details>
 
 ### Templates

--- a/examples/v2/v2.go
+++ b/examples/v2/v2.go
@@ -18,7 +18,7 @@ var (
 
 func main() {
 	// initialize new library instance
-	rt, err := router.NewV2()
+	rt, err := router.NewV2("")
 	if err != nil {
 		log.Logger.Fatal(err)
 	}

--- a/msgservice/testdata/all-in-one-image.json
+++ b/msgservice/testdata/all-in-one-image.json
@@ -599,7 +599,7 @@
                 },
                 {
                     "name": "CVE-2019-1551",
-                    "description": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u (Affected 1.0.2-1.0.2t).",
+                    "description": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to reuse the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u (Affected 1.0.2-1.0.2t).",
                     "nvd_score": 5,
                     "nvd_score_version": "CVSS v2",
                     "nvd_vectors": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -644,7 +644,7 @@
                 },
                 {
                     "name": "CVE-2020-1968",
-                    "description": "The Raccoon attack exploits a flaw in the TLS specification which can lead to an attacker being able to compute the pre-master secret in connections which have used a Diffie-Hellman (DH) based ciphersuite. In such a case this would result in the attacker being able to eavesdrop on all encrypted communications sent over that TLS connection. The attack can only be exploited if an implementation re-uses a DH secret across multiple TLS connections. Note that this issue only impacts DH ciphersuites and not ECDH ciphersuites. This issue affects OpenSSL 1.0.2 which is out of support and no longer receiving public updates. OpenSSL 1.1.1 is not vulnerable to this issue. Fixed in OpenSSL 1.0.2w (Affected 1.0.2-1.0.2v).",
+                    "description": "The Raccoon attack exploits a flaw in the TLS specification which can lead to an attacker being able to compute the pre-master secret in connections which have used a Diffie-Hellman (DH) based ciphersuite. In such a case this would result in the attacker being able to eavesdrop on all encrypted communications sent over that TLS connection. The attack can only be exploited if an implementation reuses a DH secret across multiple TLS connections. Note that this issue only impacts DH ciphersuites and not ECDH ciphersuites. This issue affects OpenSSL 1.0.2 which is out of support and no longer receiving public updates. OpenSSL 1.1.1 is not vulnerable to this issue. Fixed in OpenSSL 1.0.2w (Affected 1.0.2-1.0.2v).",
                     "nvd_score": 4.3,
                     "nvd_score_version": "CVSS v2",
                     "nvd_vectors": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
@@ -792,7 +792,7 @@
                 },
                 {
                     "name": "CVE-2019-1551",
-                    "description": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u (Affected 1.0.2-1.0.2t).",
+                    "description": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to reuse the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u (Affected 1.0.2-1.0.2t).",
                     "nvd_score": 5,
                     "nvd_score_version": "CVSS v2",
                     "nvd_vectors": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -837,7 +837,7 @@
                 },
                 {
                     "name": "CVE-2020-1968",
-                    "description": "The Raccoon attack exploits a flaw in the TLS specification which can lead to an attacker being able to compute the pre-master secret in connections which have used a Diffie-Hellman (DH) based ciphersuite. In such a case this would result in the attacker being able to eavesdrop on all encrypted communications sent over that TLS connection. The attack can only be exploited if an implementation re-uses a DH secret across multiple TLS connections. Note that this issue only impacts DH ciphersuites and not ECDH ciphersuites. This issue affects OpenSSL 1.0.2 which is out of support and no longer receiving public updates. OpenSSL 1.1.1 is not vulnerable to this issue. Fixed in OpenSSL 1.0.2w (Affected 1.0.2-1.0.2v).",
+                    "description": "The Raccoon attack exploits a flaw in the TLS specification which can lead to an attacker being able to compute the pre-master secret in connections which have used a Diffie-Hellman (DH) based ciphersuite. In such a case this would result in the attacker being able to eavesdrop on all encrypted communications sent over that TLS connection. The attack can only be exploited if an implementation reuses a DH secret across multiple TLS connections. Note that this issue only impacts DH ciphersuites and not ECDH ciphersuites. This issue affects OpenSSL 1.0.2 which is out of support and no longer receiving public updates. OpenSSL 1.1.1 is not vulnerable to this issue. Fixed in OpenSSL 1.0.2w (Affected 1.0.2-1.0.2v).",
                     "nvd_score": 4.3,
                     "nvd_score_version": "CVSS v2",
                     "nvd_vectors": "AV:N/AC:M/Au:N/C:P/I:N/A:N",

--- a/rego-templates/iac-html.rego
+++ b/rego-templates/iac-html.rego
@@ -21,8 +21,8 @@ tpl:=`
 %s
 <!-- CVE list -->
 %s
-<p><b>Resourse policy name:</b> %s</p>
-<p><b>Resourse policy application scopes:</b> %s</p>
+<p><b>Response policy name:</b> %s</p>
+<p><b>Response policy application scopes:</b> %s</p>
 `
 
 #Extra % is required in width:100%

--- a/rego-templates/iac-servicenow.rego
+++ b/rego-templates/iac-servicenow.rego
@@ -25,8 +25,8 @@ html_tpl:=`
 %s
 <!-- CVE list -->
 %s
-<p><b>Resourse policy name:</b> %s</p>
-<p><b>Resourse policy application scopes:</b> %s</p>
+<p><b>Response policy name:</b> %s</p>
+<p><b>Response policy application scopes:</b> %s</p>
 `
 
 summary_tpl =`Triggered by: %s

--- a/rego-templates/incident-servicenow.rego
+++ b/rego-templates/incident-servicenow.rego
@@ -11,8 +11,8 @@ result_tpl = `
 <p><b>Severity:</b> %s</p>
 <p><b>Data:</b> %s</p>
 
-<p><b>Resourse policy name:</b> %s</p>
-<p><b>Resourse policy application scopes:</b> %s</p>
+<p><b>Response policy name:</b> %s</p>
+<p><b>Response policy application scopes:</b> %s</p>
 `
 summary_tpl =`Category: %s
 Severity: %s`

--- a/rego-templates/insight-servicenow.rego
+++ b/rego-templates/insight-servicenow.rego
@@ -18,10 +18,10 @@ html_tpl:=`
 <p><b>Last Scan:</b> %s</p>
 <p><b>URL:</b> %s</p>
 <!-- TODO  -->
-<!-- Resourse Details -->
-<h2> <i>Resourse Details:</i> </h2>
-<p><b>Resourse ID:</b> %s</p>
-<p><b>Resourse Name:</b> %s</p>
+<!-- Response Details -->
+<h2> <i>Resource Details:</i> </h2>
+<p><b>Resource ID:</b> %s</p>
+<p><b>Resource Name:</b> %s</p>
 <p><b>ARN:</b> %s</p>
 <p><b>Extra Info:</b> %s</p>
 <!-- Evidence -->
@@ -33,8 +33,8 @@ html_tpl:=`
 <!-- Recommendation -->
 <h2> <i>Recommendation:</i> </h2>
 %s
-<p><b>Resourse policy name:</b> %s</p>
-<p><b>Resourse policy application scopes:</b> %s</p>
+<p><b>Response policy name:</b> %s</p>
+<p><b>Response policy application scopes:</b> %s</p>
 `
 
 summary_tpl =`Insight ID: %s

--- a/rego-templates/swit-text.rego
+++ b/rego-templates/swit-text.rego
@@ -20,8 +20,8 @@ Vulnerability summary
 %s
 %s
 %s
-Resourse policy name: %s
-Resourse policy application scopes: %s
+Response policy name: %s
+Response policy application scopes: %s
 %s`
 
 summary_tpl =`Name: %s

--- a/rego-templates/vuls-html.rego
+++ b/rego-templates/vuls-html.rego
@@ -7,7 +7,7 @@ import data.postee.with_default
 ################################################ Templates ################################################
 #main template to render message
 tpl:=`
-<p>Image name: %s</p>
+<p>%s name: %s</p>
 <p>Registry: %s</p>
 <p>%s</p>
 <p>%s</p>
@@ -164,17 +164,24 @@ vln_list(severity) = vlnrb {
 postee := with_default(input, "postee", {})
 aqua_server := with_default(postee, "AquaServer", "")
 
-title = sprintf("%s vulnerability scan report", [input.image])
+report_type := "Function" if{
+    input.entity_type == 1
+} else = "VM" if{
+    input.entity_type == 2
+} else = "Image"
+
+title = sprintf(`Aqua security | %s | %s | Scan report`, [report_type, input.image])
 
 aggregation_pkg := "postee.vuls.html.aggregation"
 result = msg {
 
     msg := sprintf(tpl, [
+    report_type,
     input.image,
     input.registry,
 	by_flag(
-     "Image is non-compliant",
-     "Image is compliant",
+     sprintf("%s is non-compliant", [report_type]),
+     sprintf("%s is compliant", [report_type]),
      with_default(input.image_assurance_results, "disallowed", false)
     ),
 	by_flag(

--- a/rego-templates/vuls-jira.rego
+++ b/rego-templates/vuls-jira.rego
@@ -5,11 +5,16 @@ import data.postee.with_default
 import data.postee.flat_array #converts [[{...},{...}], [{...},{...}]] to [{...},{...},{...},{...}]
 import data.postee.array_concat
 
-title = sprintf("%s vulnerability scan report", [input.image])
+report_type := "Function" if{
+    input.entity_type == 1
+} else = "VM" if{
+    input.entity_type == 2
+} else = "Image"
 
+title = sprintf(`Aqua security | %s | %s | Scan report`, [report_type, input.image])
 
 tpl:=`
-*Image name:* %s
+*%s name:* %s
 *Registry:* %s
 %s
 %s
@@ -42,11 +47,12 @@ assurance_controls(inp) = l {
 
 result = msg {
     msg := sprintf(tpl, [
+    report_type,
     input.image,
     input.registry,
 	by_flag(
-     "Image is _*non-compliant*_",
-     "Image is _*compliant*_",
+     sprintf("%s is _*non-compliant*_", [report_type]),
+     sprintf("%s is _*compliant*_", [report_type]),
      with_default(input.image_assurance_results, "disallowed", false)
     ),
 	by_flag(

--- a/rego-templates/vuls-servicenow.rego
+++ b/rego-templates/vuls-servicenow.rego
@@ -27,8 +27,8 @@ html_tpl:=`
 %s
 <!-- Negligible severity vulnerabilities -->
 %s
-<p><b>Resourse policy name:</b> %s</p>
-<p><b>Resourse policy application scopes:</b> %s</p>
+<p><b>Response policy name:</b> %s</p>
+<p><b>Response policy application scopes:</b> %s</p>
 %s
 `
 
@@ -194,11 +194,11 @@ postee := with_default(input, "postee", {})
 aqua_server := with_default(postee, "AquaServer", "")
 server_url := trim_suffix(aqua_server, "images/")
 
-report_type := "function" if{
+report_type := "Function" if{
     input.entity_type == 1
-} else = "vm" if{
+} else = "VM" if{
     input.entity_type == 2
-} else = "image"
+} else = "Image"
 
 title = sprintf(`Aqua security | %s | %s | Scan report`, [report_type, input.image])
 
@@ -207,15 +207,15 @@ title = sprintf(`Aqua security | %s | %s | Scan report`, [report_type, input.ima
 ## vm: <server_url>/#/infrastructure/<image>/node
 ## image: <server_url>/#/image/<registry>/<image>
 href := sprintf("%s%s/%s/%s", [server_url, "functions", urlquery.encode(input.registry), urlquery.encode(input.image)])  if{
-    report_type == "function"
+    report_type == "Function"
 } else = sprintf("%s%s/%s/%s", [server_url, "infrastructure", urlquery.encode(input.image), "node"]){
-    report_type == "vm"
+    report_type == "VM"
 } else = sprintf("%s%s/%s/%s", [server_url, "image", urlquery.encode(input.registry), urlquery.encode(input.image)])
 
 text :=  sprintf("%s%s/%s/%s", [server_url, "functions", input.registry, input.image]) if{
-    report_type == "function"
+    report_type == "Function"
 } else = sprintf("%s%s/%s/%s", [server_url, "infrastructure", input.image, "node"]) {
-    report_type == "vm"
+    report_type == "VM"
 } else = sprintf("%s%s/%s/%s", [server_url, report_type, input.registry, input.image])
 
 url := by_flag("", href, server_url == "")
@@ -269,9 +269,9 @@ result = msg {
 result_date = input.scan_started.seconds
 
 result_category = "Serverless functions Scanning" if {
-    report_type == "function"
+    report_type == "Function"
 }else = "Security - VM Scan results" if {
-    report_type == "vm"
+    report_type == "VM"
 }else = "Security Image Scan results"
 
 result_subcategory = "Security incident"

--- a/rego-templates/vuls-slack.rego
+++ b/rego-templates/vuls-slack.rego
@@ -117,7 +117,13 @@ got_vulns(vulnsAll) = [] { #do not render section if provided collection is empt
 }
 
 ###########################################################################################################
-title = sprintf("%s vulnerability scan report", [input.image]) # title is string
+report_type := "Function" if{
+    input.entity_type == 1
+} else = "VM" if{
+    input.entity_type == 2
+} else = "Image"
+
+title = sprintf(`Aqua security | %s | %s | Scan report`, [report_type, input.image])
 
 aggregation_pkg := "postee.vuls.slack.aggregation"
 
@@ -142,11 +148,11 @@ result = res {
     ])
 
 
-	headers1 := [{"type":"section","text":{"type":"mrkdwn","text":sprintf("Image name: %s", [input.image])}},
+	headers1 := [{"type":"section","text":{"type":"mrkdwn","text":sprintf("%s name: %s", [report_type ,input.image])}},
     			{"type":"section","text":{"type":"mrkdwn","text":sprintf("Registry: %s", [input.registry])}},
     			{"type":"section","text":{"type":"mrkdwn","text": by_flag(
-                                                                        "Image is non-compliant",
-                                                                        "Image is compliant",
+                                                                        sprintf("%s is non-compliant", [report_type]),
+                                                                        sprintf("%s is compliant", [report_type]),
                                                                         with_default(input.image_assurance_results, "disallowed", false)
                                                                     )}},
     			{"type":"section","text":{"type":"mrkdwn","text": by_flag(


### PR DESCRIPTION
This commit aligns the vuls templates to present the type of the scanned entity instead of hard coded "image" as it used to be and replacing "resourse" with "response" policy. In addition, it fixes several unrelated tests that were broken.

Resolves: SLK-71876