### PR TITLE
Bug fix | Rego templates with a link to Aqua navigate to "url" instead of the real URL

### DIFF
--- a/rego-templates/incident-servicenow.rego
+++ b/rego-templates/incident-servicenow.rego
@@ -13,7 +13,7 @@ result_tpl = `
 
 <p><b>Response policy name:</b> %s</p>
 <p><b>Response policy application scopes:</b> %s</p>
-<p><b>See more:</b> <a href="url">%s</a></p>
+<p><b>See more:</b> <a href="%s">%s</a></p>
 `
 summary_tpl =`Category: %s
 Severity: %s`
@@ -104,6 +104,7 @@ result := res{
             	found_data == ""),
         with_default(input,"response_policy_name", "response policy name not found"),
         with_default(input,"application_scope", "none"),
+        with_default(input, "url", ""),
         with_default(input, "url", "")
     ])
 }

--- a/rego-templates/vuls-html.rego
+++ b/rego-templates/vuls-html.rego
@@ -33,7 +33,7 @@ tpl:=`
 
 <p>Response policy name: %s</p>
 <p>Response policy application scopes: %s</p>
-<p>See more: <a href="url">%s</a></p>
+<p>See more: <a href="%s">%s</a></p>
 `
 
 vlnrb_tpl = `
@@ -206,6 +206,7 @@ result = msg {
     render_vlnrb("Negligible", vln_list("negligible")),
     input.response_policy_name,
     concat(", ", with_default(input, "application_scope", [])),
+    with_default(input, "url", ""),
     with_default(input, "url", "")
     ])
 }

--- a/rego-templates/vuls-servicenow.rego
+++ b/rego-templates/vuls-servicenow.rego
@@ -29,7 +29,7 @@ html_tpl:=`
 %s
 <p><b>Response policy name:</b> %s</p>
 <p><b>Response policy application scopes:</b> %s</p>
-<p><b>See more:</b> <a href="url">%s</a></p>
+<p><b>See more:</b> <a href="%s">%s</a></p>
 `
 
 summary_tpl =`Name: %s
@@ -236,6 +236,7 @@ result = msg {
     render_vlnrb("Negligible", vln_list("negligible")),
     with_default(input,"response_policy_name", ""),
     with_default(input,"application_scope", "none"),
+    with_default(input, "url", ""),
     with_default(input, "url", "")
     ])
 }


### PR DESCRIPTION
Some rego templates were defined with a link to "url" like so:
`<a href="url">`
but the url is not a variable, so the links would send customers to "url", instead of the real URL.
To fix the issue, the href value is changed to:
`<a href="%s">`
and the %s is populated with the real URL.