### PR TITLE
SLK-87780 | Fix failed sent email when app scope owner is empty

### DIFF
--- a/outputs/email.go
+++ b/outputs/email.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aquasecurity/postee/v2/data"
 	"github.com/aquasecurity/postee/v2/formatting"
@@ -153,12 +154,14 @@ func (email *EmailOutput) Send(content map[string]string) (data.OutputResponse, 
 		return email.sendViaAwsSesService(email.AwsSesConfig, subject, body, recipients)
 	}
 
+	date := time.Now().Format(time.RFC1123Z)
 	msg := fmt.Sprintf(
 		"To: %s\r\n"+
 			"From: %s\r\n"+
 			"Subject: %s\r\n"+
+			"Date: %s\r\n"+
 			"Content-Type: text/html; charset=UTF-8\r\n\r\n%s\r\n",
-		strings.Join(recipients, ","), email.Sender, subject, body)
+		strings.Join(recipients, ","), email.Sender, subject, date, body)
 
 	if email.UseMX {
 		email.sendViaMxServers(port, msg, recipients)

--- a/outputs/plugin.go
+++ b/outputs/plugin.go
@@ -42,8 +42,12 @@ func getHandledRecipients(recipients []string, content *map[string]string, outpu
 				log.Logger.Errorf("get application scope owners error for %q: %v", outputName, err)
 				continue
 			}
-			result = append(result, owners...)
-		} else {
+			for _, owner := range owners {
+				if owner != "" {
+					result = append(result, owner)
+				}
+			}
+		} else if r != "" {
 			result = append(result, r)
 		}
 	}

--- a/router/router.go
+++ b/router/router.go
@@ -672,7 +672,12 @@ func (ctx *Router) publish(msg map[string]interface{}, r *routes.InputRoute) []d
 
 	for _, name := range r.Outputs {
 		go func(svc service, outputName string, in map[string]interface{}, route *routes.InputRoute) {
-			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					log.Logger.Errorf("Panic in output %s: %v", outputName, r)
+				}
+				wg.Done()
+			}()
 
 			ticket, err := ctx.publishOutput(svc, outputName, in, route)
 			if err != nil {


### PR DESCRIPTION
This ticket aims to fix:

1. Correct expected format of email
2. Disregard empty string in case server sent (should not happen but you never know)
3. Use panic recovery in any case of panic error. Though that piece of code should continue the loop and send other emails present in job, it does not perform as expected so I added it just in case.

Related PR in Server: https://bitbucket.org/scalock/server/pull-requests/28142


Resolves: SLK-87780