### PR TITLE
Vulnerability Email Template | The template shows a copyright statement from 2022

### DIFF
--- a/rego-templates/vuls-email.rego
+++ b/rego-templates/vuls-email.rego
@@ -88,9 +88,6 @@ tpl := `
   <div class="see-more-container">
     <a href="%s" class="see-more">See more</a>
   </div>
-  <div class="copyright">
-    Copyright (C) 2022 Aqua Security Software Ltd.
-  </div>
 </body>
 </html>
 `
@@ -243,14 +240,6 @@ style:=`
       width:100%;
       display: flex;
       justify-content: center;
-    }
-    .copyright {
-      color: #405a75;
-      font-family: "Inter-SemiBold", sans-serif;
-      font-size: 15px;
-      line-height: 26px;
-      font-weight: 600;
-      margin-top: 30px;
     }
     .properties-container {
       display: flex;


### PR DESCRIPTION
Removed the copyright statement from the vunerabilities email template, as we looked into the original design in Figma and it is not there. Plus, it says 2022 and looks outdated.