### PR TITLE
Jira Integration | Detect Cloud deployment via serverInfo API instead…

### DIFF
--- a/outputs/jira.go
+++ b/outputs/jira.go
@@ -45,6 +45,7 @@ type JiraAPI struct {
 	BoardName       string
 	boardId         int
 	boardType       string
+	isCloud         bool
 }
 
 func (ctx *JiraAPI) GetType() string {
@@ -77,15 +78,9 @@ func (ctx *JiraAPI) CloneSettings() *data.OutputSettings {
 	}
 }
 
-func (ctx *JiraAPI) fetchBoardId(boardName string) {
+func (ctx *JiraAPI) fetchBoardId(client *jira.Client, boardName string) {
 	// Basic authentication with passwords is deprecated for this API
 	if ctx.Token == "" {
-		return
-	}
-
-	client, err := ctx.createClient()
-	if err != nil {
-		log.Logger.Error(fmt.Errorf("unable to create Jira client: %w, please check your credentials", err))
 		return
 	}
 
@@ -141,13 +136,21 @@ func (ctx *JiraAPI) Init() error {
 	if ctx.BoardName == "" {
 		ctx.BoardName = fmt.Sprintf("%s board", ctx.ProjectKey)
 	}
-	ctx.fetchBoardId(ctx.BoardName)
 
 	if len(ctx.Password) == 0 {
 		ctx.Password = os.Getenv("JIRA_PASSWORD")
 	}
 
-	log.Logger.Infof("Successfully initialized Jira output %q", ctx.Name)
+	client, err := ctx.createClient()
+	if err != nil {
+		log.Logger.Warnf("Could not create Jira client during init: %v", err)
+		return err
+	}
+
+	ctx.isCloud = ctx.getIsCloud(client)
+	ctx.fetchBoardId(client, ctx.BoardName)
+	log.Logger.Infof("Successfully initialized Jira output %q (cloud=%v)", ctx.Name, ctx.isCloud)
+
 	return nil
 }
 
@@ -157,7 +160,7 @@ func (ctx *JiraAPI) GetLayoutProvider() layout.LayoutProvider {
 
 func (ctx *JiraAPI) buildTransportClient() (*http.Client, error) {
 	if ctx.Token != "" {
-		if !isServerJira(ctx.Url) {
+		if ctx.isCloud {
 			return nil, errors.New("jira Cloud can't work with PAT")
 		}
 		if ctx.Password != "" {
@@ -261,7 +264,7 @@ func (ctx *JiraAPI) Send(content map[string]string) (data.OutputResponse, error)
 		Name string `json:"name"`
 	}
 
-	issue, err := InitIssue(client, metaProject, metaIssueType, fieldsConfig, isServerJira(ctx.Url))
+	issue, err := InitIssue(client, metaProject, metaIssueType, fieldsConfig, !ctx.isCloud)
 
 	if err != nil {
 		log.Logger.Error(fmt.Errorf("failed to init issue: %w", err))
@@ -472,14 +475,29 @@ func findUserOnJiraServer(c *jira.Client, email string) ([]jira.User, *jira.Resp
 	return users, resp, nil
 }
 
-func isServerJira(rawUrl string) bool {
-	jiraUrl, err := url.Parse(rawUrl)
-
-	if err == nil {
-		return !strings.HasSuffix(jiraUrl.Host, "atlassian.net")
+// getIsCloud probes /rest/api/2/serverInfo to determine the Jira deployment
+// type. Falls back to the URL-based heuristic when the probe fails.
+func (ctx *JiraAPI) getIsCloud(client *jira.Client) bool {
+	req, err := client.NewRequest("GET", "rest/api/2/serverInfo", nil)
+	if err != nil {
+		log.Logger.Warnf("Failed to build serverInfo request, falling back to URL check: %v", err)
+		return isCloudUrl(ctx.Url)
 	}
+	info := new(jira.JiraServerInfo)
+	resp, err := client.Do(req, info)
+	if err != nil || resp == nil || resp.StatusCode != http.StatusOK {
+		log.Logger.Warnf("serverInfo probe failed, falling back to URL check: %v", err)
+		return isCloudUrl(ctx.Url)
+	}
+	return strings.EqualFold(info.DeploymentType, "Cloud")
+}
 
-	return false
+func isCloudUrl(rawUrl string) bool {
+	jiraUrl, err := url.Parse(rawUrl)
+	if err != nil {
+		return false
+	}
+	return strings.HasSuffix(jiraUrl.Host, "atlassian.net")
 }
 
 func cpyUnknowns(source map[string]string) map[string]string {

--- a/outputs/jira.go
+++ b/outputs/jira.go
@@ -1,7 +1,6 @@
 package outputs
 
 import (
-	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -11,6 +10,7 @@ import (
 	"github.com/aquasecurity/postee/v2/formatting"
 	"github.com/aquasecurity/postee/v2/layout"
 	"github.com/aquasecurity/postee/v2/log"
+	"github.com/trivago/tgo/tcontainer"
 
 	"net/http"
 	"net/url"
@@ -315,20 +315,13 @@ func (ctx *JiraAPI) openIssue(client *jira.Client, issue *jira.Issue) (*jira.Iss
 }
 
 func createMetaProject(c *jira.Client, project string, isCloud bool) (*jira.MetaProject, error) {
-	var meta *jira.CreateMetaInfo
-	var err error
-
 	log.Logger.Debugf("Fetching create meta for project %q (cloud=%v)", project, isCloud)
 
 	if isCloud {
-		meta, _, err = c.Issue.GetCreateMetaWithOptionsWithContextForJira9(
-			context.Background(),
-			&jira.GetQueryOptions{ProjectKeys: project, Expand: "projects.issuetypes.fields"},
-		)
-	} else {
-		meta, _, err = c.Issue.GetCreateMeta(project)
+		return createMetaProjectCloud(c, project)
 	}
 
+	meta, _, err := c.Issue.GetCreateMeta(project)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get create meta: %w", err)
 	}
@@ -341,6 +334,94 @@ func createMetaProject(c *jira.Client, project string, isCloud bool) (*jira.Meta
 	}
 
 	return metaProject, nil
+}
+
+func createMetaProjectCloud(c *jira.Client, project string) (*jira.MetaProject, error) {
+	type issueTypeEntry struct {
+		Id   string `json:"id"`
+		Name string `json:"name"`
+	}
+	type issueTypesPage struct {
+		IssueTypes []issueTypeEntry `json:"issueTypes"`
+		Values     []issueTypeEntry `json:"values"`
+	}
+
+	issueTypesEndpoint := fmt.Sprintf("rest/api/2/issue/createmeta/%s/issuetypes", project)
+	req, err := c.NewRequest("GET", issueTypesEndpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for %s: %w", issueTypesEndpoint, err)
+	}
+
+	var page issueTypesPage
+	if _, err := c.Do(req, &page); err != nil {
+		return nil, fmt.Errorf("failed to get issue types from %s: %w", issueTypesEndpoint, err)
+	}
+
+	issueTypes := page.IssueTypes
+	if len(issueTypes) == 0 {
+		issueTypes = page.Values
+	}
+	if len(issueTypes) == 0 {
+		return nil, fmt.Errorf("no issue types returned for project %s (check project key and permissions)", project)
+	}
+
+	log.Logger.Debugf("Found %d issue type(s) for project %q", len(issueTypes), project)
+
+	metaProject := &jira.MetaProject{Key: project}
+	for _, it := range issueTypes {
+		log.Logger.Debugf("Fetching fields for issue type %q (id=%s)", it.Name, it.Id)
+		fields, err := fetchIssueTypeFields(c, project, it.Id)
+		if err != nil {
+			return nil, err
+		}
+		metaProject.IssueTypes = append(metaProject.IssueTypes, &jira.MetaIssueType{
+			Id:     it.Id,
+			Name:   it.Name,
+			Fields: fields,
+		})
+	}
+
+	log.Logger.Debugf("Cloud create meta returned %d issue type(s) for project %q", len(metaProject.IssueTypes), project)
+	return metaProject, nil
+}
+
+func fetchIssueTypeFields(c *jira.Client, project, issueTypeId string) (tcontainer.MarshalMap, error) {
+	endpoint := fmt.Sprintf("rest/api/2/issue/createmeta/%s/issuetypes/%s", project, issueTypeId)
+	req, err := c.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for %s: %w", endpoint, err)
+	}
+
+	type fieldsPage struct {
+		Fields []tcontainer.MarshalMap `json:"fields"`
+		Values []tcontainer.MarshalMap `json:"values"`
+	}
+
+	var page fieldsPage
+	if _, err := c.Do(req, &page); err != nil {
+		return nil, fmt.Errorf("failed to get fields from %s: %w", endpoint, err)
+	}
+
+	entries := page.Fields
+	if len(entries) == 0 {
+		entries = page.Values
+	}
+
+	var skipped int
+	fields := tcontainer.MarshalMap{}
+	for _, v := range entries {
+		fieldId, err := v.String("fieldId")
+		if err != nil {
+			skipped++
+			continue
+		}
+		fields[fieldId] = v
+	}
+	if skipped > 0 {
+		log.Logger.Warnf("Skipped %d field(s) without fieldId for issue type %s in project %s", skipped, issueTypeId, project)
+	}
+	log.Logger.Debugf("Loaded %d field(s) for issue type %s in project %s", len(fields), issueTypeId, project)
+	return fields, nil
 }
 
 func createMetaIssueType(metaProject *jira.MetaProject, issueType string) (*jira.MetaIssueType, error) {
@@ -430,9 +511,15 @@ func InitIssue(c *jira.Client, metaProject *jira.MetaProject, metaIssuetype *jir
 			// Treat any as string
 			issueFields.Unknowns[jiraKey] = value
 		case "project":
-			issueFields.Unknowns[jiraKey] = jira.Project{
-				Name: metaProject.Name,
-				ID:   metaProject.Id,
+			if metaProject.Id != "" {
+				issueFields.Unknowns[jiraKey] = jira.Project{
+					Name: metaProject.Name,
+					ID:   metaProject.Id,
+				}
+			} else {
+				issueFields.Unknowns[jiraKey] = jira.Project{
+					Key: metaProject.Key,
+				}
 			}
 		case "priority":
 			issueFields.Unknowns[jiraKey] = jira.Priority{Name: value}

--- a/outputs/jira.go
+++ b/outputs/jira.go
@@ -4,13 +4,13 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 
 	"github.com/aquasecurity/postee/v2/data"
 	"github.com/aquasecurity/postee/v2/formatting"
 	"github.com/aquasecurity/postee/v2/layout"
 	"github.com/aquasecurity/postee/v2/log"
-	"github.com/trivago/tgo/tcontainer"
 
 	"net/http"
 	"net/url"
@@ -336,92 +336,35 @@ func createMetaProject(c *jira.Client, project string, isCloud bool) (*jira.Meta
 	return metaProject, nil
 }
 
+// createMetaProjectCloud calls the createmeta endpoint directly, bypassing the
+// SDK's internal isJiraAPI9 routing which incorrectly routes some Cloud
+// instances to the Server-only /rest/api/2/project/{key} endpoint.
 func createMetaProjectCloud(c *jira.Client, project string) (*jira.MetaProject, error) {
-	type issueTypeEntry struct {
-		Id   string `json:"id"`
-		Name string `json:"name"`
-	}
-	type issueTypesPage struct {
-		IssueTypes []issueTypeEntry `json:"issueTypes"`
-		Values     []issueTypeEntry `json:"values"`
-	}
-
-	issueTypesEndpoint := fmt.Sprintf("rest/api/2/issue/createmeta/%s/issuetypes", project)
-	req, err := c.NewRequest("GET", issueTypesEndpoint, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request for %s: %w", issueTypesEndpoint, err)
-	}
-
-	var page issueTypesPage
-	if _, err := c.Do(req, &page); err != nil {
-		return nil, fmt.Errorf("failed to get issue types from %s: %w", issueTypesEndpoint, err)
-	}
-
-	issueTypes := page.IssueTypes
-	if len(issueTypes) == 0 {
-		issueTypes = page.Values
-	}
-	if len(issueTypes) == 0 {
-		return nil, fmt.Errorf("no issue types returned for project %s (check project key and permissions)", project)
-	}
-
-	log.Logger.Debugf("Found %d issue type(s) for project %q", len(issueTypes), project)
-
-	metaProject := &jira.MetaProject{Key: project}
-	for _, it := range issueTypes {
-		log.Logger.Debugf("Fetching fields for issue type %q (id=%s)", it.Name, it.Id)
-		fields, err := fetchIssueTypeFields(c, project, it.Id)
-		if err != nil {
-			return nil, err
-		}
-		metaProject.IssueTypes = append(metaProject.IssueTypes, &jira.MetaIssueType{
-			Id:     it.Id,
-			Name:   it.Name,
-			Fields: fields,
-		})
-	}
-
-	log.Logger.Debugf("Cloud create meta returned %d issue type(s) for project %q", len(metaProject.IssueTypes), project)
-	return metaProject, nil
-}
-
-func fetchIssueTypeFields(c *jira.Client, project, issueTypeId string) (tcontainer.MarshalMap, error) {
-	endpoint := fmt.Sprintf("rest/api/2/issue/createmeta/%s/issuetypes/%s", project, issueTypeId)
+	endpoint := fmt.Sprintf("rest/api/2/issue/createmeta?projectKeys=%s&expand=projects.issuetypes.fields", project)
 	req, err := c.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for %s: %w", endpoint, err)
 	}
 
-	type fieldsPage struct {
-		Fields []tcontainer.MarshalMap `json:"fields"`
-		Values []tcontainer.MarshalMap `json:"values"`
-	}
-
-	var page fieldsPage
-	if _, err := c.Do(req, &page); err != nil {
-		return nil, fmt.Errorf("failed to get fields from %s: %w", endpoint, err)
-	}
-
-	entries := page.Fields
-	if len(entries) == 0 {
-		entries = page.Values
-	}
-
-	var skipped int
-	fields := tcontainer.MarshalMap{}
-	for _, v := range entries {
-		fieldId, err := v.String("fieldId")
-		if err != nil {
-			skipped++
-			continue
+	meta := new(jira.CreateMetaInfo)
+	resp, err := c.Do(req, meta)
+	if err != nil {
+		if resp != nil && resp.Body != nil {
+			body, _ := io.ReadAll(resp.Body)
+			log.Logger.Debugf("Response body from %s (status %d): %s", endpoint, resp.StatusCode, string(body))
 		}
-		fields[fieldId] = v
+		return nil, fmt.Errorf("failed to get create meta from %s: %w", endpoint, err)
 	}
-	if skipped > 0 {
-		log.Logger.Warnf("Skipped %d field(s) without fieldId for issue type %s in project %s", skipped, issueTypeId, project)
+
+	log.Logger.Debugf("Createmeta response for project %q: %d project(s) returned", project, len(meta.Projects))
+
+	metaProject := meta.GetProjectWithKey(project)
+	if metaProject == nil {
+		return nil, fmt.Errorf("could not find project with key %s", project)
 	}
-	log.Logger.Debugf("Loaded %d field(s) for issue type %s in project %s", len(fields), issueTypeId, project)
-	return fields, nil
+
+	log.Logger.Debugf("Cloud createmeta returned project %q with %d issue type(s)", project, len(metaProject.IssueTypes))
+	return metaProject, nil
 }
 
 func createMetaIssueType(metaProject *jira.MetaProject, issueType string) (*jira.MetaIssueType, error) {
@@ -511,15 +454,9 @@ func InitIssue(c *jira.Client, metaProject *jira.MetaProject, metaIssuetype *jir
 			// Treat any as string
 			issueFields.Unknowns[jiraKey] = value
 		case "project":
-			if metaProject.Id != "" {
-				issueFields.Unknowns[jiraKey] = jira.Project{
-					Name: metaProject.Name,
-					ID:   metaProject.Id,
-				}
-			} else {
-				issueFields.Unknowns[jiraKey] = jira.Project{
-					Key: metaProject.Key,
-				}
+			issueFields.Unknowns[jiraKey] = jira.Project{
+				Name: metaProject.Name,
+				ID:   metaProject.Id,
 			}
 		case "priority":
 			issueFields.Unknowns[jiraKey] = jira.Priority{Name: value}

--- a/outputs/jira.go
+++ b/outputs/jira.go
@@ -1,6 +1,7 @@
 package outputs
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -213,7 +214,7 @@ func (ctx *JiraAPI) Send(content map[string]string) (data.OutputResponse, error)
 		ctx.fetchSprintId(*client)
 	}
 
-	metaProject, err := createMetaProject(client, ctx.ProjectKey)
+	metaProject, err := createMetaProject(client, ctx.ProjectKey, ctx.isCloud)
 	if err != nil {
 		return data.OutputResponse{}, fmt.Errorf("failed to create meta project: %w", err)
 	}
@@ -313,13 +314,27 @@ func (ctx *JiraAPI) openIssue(client *jira.Client, issue *jira.Issue) (*jira.Iss
 	return i, nil
 }
 
-func createMetaProject(c *jira.Client, project string) (*jira.MetaProject, error) {
-	meta, _, err := c.Issue.GetCreateMeta(project)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get create meta : %w", err)
+func createMetaProject(c *jira.Client, project string, isCloud bool) (*jira.MetaProject, error) {
+	var meta *jira.CreateMetaInfo
+	var err error
+
+	log.Logger.Debugf("Fetching create meta for project %q (cloud=%v)", project, isCloud)
+
+	if isCloud {
+		meta, _, err = c.Issue.GetCreateMetaWithOptionsWithContextForJira9(
+			context.Background(),
+			&jira.GetQueryOptions{ProjectKeys: project, Expand: "projects.issuetypes.fields"},
+		)
+	} else {
+		meta, _, err = c.Issue.GetCreateMeta(project)
 	}
 
-	// get right project
+	if err != nil {
+		return nil, fmt.Errorf("failed to get create meta: %w", err)
+	}
+
+	log.Logger.Debugf("Create meta response: %+v", meta)
+
 	metaProject := meta.GetProjectWithKey(project)
 	if metaProject == nil {
 		return nil, fmt.Errorf("could not find project with key %s", project)


### PR DESCRIPTION
Jira Cloud instances with custom domains (not ending in "atlassian.net") were misclassified as Server type deployement, causing user search and PAT validation to use the wrong API paths. Replaced the URL-based check with a /rest/api/2/serverInfo probe that reads the deploymentType field from the API. The URL check is kept as a fallback when the probe fails, preserving backward compatibility. Also refactored Init() to share a single client across the serverInfo probe and board fetch.