### PR TITLE
fix(layout): guard VulnerabilitiesTable against a short row

### DIFF
--- a/layout/vulnerabilities.go
+++ b/layout/vulnerabilities.go
@@ -54,7 +54,7 @@ func RenderVulnerabilities(resources []data.InfoResources, provider LayoutProvid
 }
 
 func VulnerabilitiesTable(provider LayoutProvider, rows [2][]string) string {
-	if len(rows) != 2 && len(rows[1]) != 5 {
+	if len(rows) != 2 || len(rows[1]) != 5 {
 		return ""
 	}
 	var table [][]string

--- a/layout/vulnerabilities_short_test.go
+++ b/layout/vulnerabilities_short_test.go
@@ -1,0 +1,37 @@
+package layout
+
+import "testing"
+
+// shortRowProvider is a minimal LayoutProvider for exercising VulnerabilitiesTable.
+type shortRowProvider struct{}
+
+func (shortRowProvider) TitleH1(title string) string          { return title }
+func (shortRowProvider) TitleH2(title string) string          { return title }
+func (shortRowProvider) TitleH3(title string) string          { return title }
+func (shortRowProvider) ColourText(text, color string) string { return text }
+func (shortRowProvider) Table(rows [][]string) string         { return "table" }
+func (shortRowProvider) P(p string) string                    { return p }
+func (shortRowProvider) A(url, title string) string           { return url }
+
+func TestVulnerabilitiesTableShortRowReturnsEmpty(t *testing.T) {
+	// rows[1] has only 3 columns, not the 5 the function indexes into.
+	// The guard is supposed to reject this and return "".
+	rows := [2][]string{
+		{"CRITICAL", "HIGH", "MEDIUM", "LOW", "NEGLIGIBLE"},
+		{"1", "2", "3"},
+	}
+	got := VulnerabilitiesTable(shortRowProvider{}, rows)
+	if got != "" {
+		t.Fatalf("expected empty string for a short row, got %q", got)
+	}
+}
+
+func TestVulnerabilitiesTableFullRowRenders(t *testing.T) {
+	rows := [2][]string{
+		{"CRITICAL", "HIGH", "MEDIUM", "LOW", "NEGLIGIBLE"},
+		{"1", "2", "3", "4", "5"},
+	}
+	if got := VulnerabilitiesTable(shortRowProvider{}, rows); got != "table" {
+		t.Fatalf("expected the table to render, got %q", got)
+	}
+}


### PR DESCRIPTION
The guard at the top of `VulnerabilitiesTable` can't actually reject a bad row.

`rows` is a `[2][]string`, so `len(rows)` is always 2 and `len(rows) != 2` is always false. With the `&&` that makes the whole condition always false, so the guard never returns and the function goes on to index `rows[1][0]` through `rows[1][4]` unconditionally. If the second row has fewer than 5 columns that is an index out of range panic.

Switching the operator to `||` makes the check do what it was written for: bail out with an empty string unless the second row has the 5 columns the code reads. The current caller in `ticketLayout.go` always passes 5 columns, so this doesn't change existing behavior, it just stops the exported helper from panicking on a shorter row.

Added a small test that passes a 3-column row (panics before this change, returns "" after) plus one that confirms a full 5-column row still renders. `go test ./layout/` is green.

I do supply-chain-security contributions across open-source projects; happy to adjust if you'd prefer a different guard shape.